### PR TITLE
For users without any mentors (like admins) just display the main list

### DIFF
--- a/seumich/views.py
+++ b/seumich/views.py
@@ -211,6 +211,11 @@ class ClassSiteView(LoginRequiredMixin, UserLogPageViewMixin, PaginationMixin,
 class IndexView(LoginRequiredMixin, UserLogPageViewMixin, View):
 
     def get(self, request):
+        # If the user has no mentors (is an admin) just redirect to main list
+        try:
+            has_mentor = Mentor.objects.get(username=request.user.username)
+        except Mentor.DoesNotExist:
+            return redirect('seumich:advisors_list')
         return redirect('seumich:advisor', advisor=request.user.username)
 
 

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -215,6 +215,8 @@ class IndexView(LoginRequiredMixin, UserLogPageViewMixin, View):
         try:
             has_mentor = Mentor.objects.get(username=request.user.username)
         except Mentor.DoesNotExist:
+            logger.info('(%s) not found as mentor. Redirecting to advisors_list'
+                            % request.user.username)
             return redirect('seumich:advisors_list')
         return redirect('seumich:advisor', advisor=request.user.username)
 


### PR DESCRIPTION
instead of advisors page

Fixes #28