### PR TITLE
Updating About page and adding About link to navigation bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# IDE resources
+.idea

--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div class="container content">
-        <h2 class="header">About Student Explorer</h2>
+        <h1 class="header">About Student Explorer</h1>
         <p>Student Explorer is an early warning system that leverages Learning Management System data to <b>help
             academic advisors identify at-risk students.</b> It uses learning analytics techniques to create actionable
             intelligence that assists academic advisors in identifying students at risk of academic jeopardy in order to
@@ -35,6 +35,13 @@
         </p>
 
         <hr/>
+
+        <h2 class="header">Technical Information</h2>
+        <p>The <a href="https://github.com/tl-its-umich-edu/student_explorer">GitHub repository</a> for Student Explorer
+            is public. View <a href="https://github.com/tl-its-umich-edu/student_explorer/releases">release notes</a>
+            for Student Explorer.
+        </p>
+
         <p>Build Name:
             <strong>{{ build_name }}</strong>
         </p>

--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -8,19 +8,19 @@
             intelligence that assists academic advisors in identifying students at risk of academic jeopardy in order to
             facilitate outreach to these students. The tool helps advisors create timely interventions to direct
             students toward resources or behavioral changes that help facilitate future student success. Student
-            Explorer is available to all academic advisors at the U-M Ann Arbor campus upon request for access and
-            includes information about all students on the Ann Arbor campus, including graduate students. For more
-            information about how Student Explorer works and how to use it, please refer to the
+            Explorer is available to <b>all academic advisors at the U-M Ann Arbor campus upon request for access</b>
+            and includes information about <b>all students on the Ann Arbor campus, including graduate students.</b> For
+            more information about how Student Explorer works and how to use it, please refer to the
             <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>.
         </p>
 
         <h2 class="header">About Cohorts</h2>
         <p>Student Explorer operates using a cohort model; students are assigned to advisors using cohorts so that
-            advisors can see all of their students in their "My Students" tab. <b>You do not need to have cohorts in
-            order to use Student Explorer</b> &#151; you can search for students individually using the search bar in
-            the upper right, or navigate to an individual student's page using the link under "Term Progress" in the LSA
-            Undergraduate Student Advising File. However, if you would like to set up a cohort to see all of your
-            students in one list, please follow the instructions in the
+            advisors can see all of their students in their <a href="/">"My Students" tab</a>. <b>You do not need to
+            have cohorts in order to use Student Explorer</b> &#151; you can search for students individually using the
+            search bar in the upper right, or navigate to an individual student's page using the link under "Term
+            Progress" in the LSA Undergraduate Student Advising File. However, if you would like to set up a cohort to
+            see all of your students in one list, please follow the instructions in the
             <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>. <b>Cohorts are
             not connected to advisor assignments in Wolverine Access or the LSA Undergraduate Student Advising
             File.</b>
@@ -30,8 +30,8 @@
         <p>Student Explorer was started as a research project in 2011 led by Professor Stephanie Teasley and Dr. Steven
             Lonn in partnership with M-STEM Academies. LSA Technology Services, Academic Innovation, and ITS Teaching &
             Learning have contributed to the design, development, and management of the tool. Student Explorer is
-            currently run by ITS Teaching & Learning, and questions and comments can be directed to the team by
-            <a href="/feedback">submitting feedback</a>.
+            currently run by ITS Teaching & Learning, and <b>questions and comments can be directed to the team by
+            <a href="/feedback">submitting feedback</a>.</b>
         </p>
 
         <hr/>

--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -2,8 +2,38 @@
 
 {% block content %}
     <div class="container content">
-        <h1 class="sub-header">About Student Explorer</h1>
-        <p>Student Explorer is an early warning system that leverages Learning Management System data to help academic advisors identify at-risk students. (<a href="http://digitaleducation.umich.edu/dei/student-explorer/" target="_blank">more info</a>)</p>
+        <h2 class="header">About Student Explorer</h2>
+        <p>Student Explorer is an early warning system that leverages Learning Management System data to <b>help
+            academic advisors identify at-risk students.</b> It uses learning analytics techniques to create actionable
+            intelligence that assists academic advisors in identifying students at risk of academic jeopardy in order to
+            facilitate outreach to these students. The tool helps advisors create timely interventions to direct
+            students toward resources or behavioral changes that help facilitate future student success. Student
+            Explorer is available to all academic advisors at the U-M Ann Arbor campus upon request for access and
+            includes information about all students on the Ann Arbor campus, including graduate students. For more
+            information about how Student Explorer works and how to use it, please refer to the
+            <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>.
+        </p>
+
+        <h2 class="header">About Cohorts</h2>
+        <p>Student Explorer operates using a cohort model; students are assigned to advisors using cohorts so that
+            advisors can see all of their students in their "My Students" tab. <b>You do not need to have cohorts in
+            order to use Student Explorer</b> &#151; you can search for students individually using the search bar in
+            the upper right, or navigate to an individual student's page using the link under "Term Progress" in the LSA
+            Undergraduate Student Advising File. However, if you would like to set up a cohort to see all of your
+            students in one list, please follow the instructions in the
+            <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>. <b>Cohorts are
+            not connected to advisor assignments in Wolverine Access or the LSA Undergraduate Student Advising
+            File.</b>
+        </p>
+
+        <h2 class="header">Student Explorer History</h2>
+        <p>Student Explorer was started as a research project in 2011 led by Professor Stephanie Teasley and Dr. Steven
+            Lonn in partnership with M-STEM Academies. LSA Technology Services, Academic Innovation, and ITS Teaching &
+            Learning have contributed to the design, development, and management of the tool. Student Explorer is
+            currently run by ITS Teaching & Learning, and questions and comments can be directed to the team by
+            <a href="/feedback">submitting feedback</a>.
+        </p>
+
         <hr/>
         <p>Build Name:
             <strong>{{ build_name }}</strong>

--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <div class="container content">
-        <h1 class="header">About Student Explorer</h1>
+        <h1 class="sub-header">About Student Explorer</h1>
         <p>Student Explorer is an early warning system that leverages Learning Management System data to <b>help
             academic advisors identify at-risk students.</b> It uses learning analytics techniques to create actionable
             intelligence that assists academic advisors in identifying students at risk of academic jeopardy in order to
@@ -14,7 +14,7 @@
             <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>.
         </p>
 
-        <h2 class="header">About Cohorts</h2>
+        <h2 class="list-header">About Cohorts</h2>
         <p>Student Explorer operates using a cohort model; students are assigned to advisors using cohorts so that
             advisors can see all of their students in their <a href="/">"My Students" tab</a>. <b>You do not need to
             have cohorts in order to use Student Explorer</b> &#151; you can search for students individually using the
@@ -26,7 +26,7 @@
             File.</b>
         </p>
 
-        <h2 class="header">Student Explorer History</h2>
+        <h2 class="list-header">Student Explorer History</h2>
         <p>Student Explorer was started as a research project in 2011 led by Professor Stephanie Teasley and Dr. Steven
             Lonn in partnership with M-STEM Academies. LSA Technology Services, Academic Innovation, and ITS Teaching &
             Learning have contributed to the design, development, and management of the tool. Student Explorer is
@@ -36,7 +36,7 @@
 
         <hr/>
 
-        <h2 class="header">Technical Information</h2>
+        <h2 class="list-header">Technical Information</h2>
         <p>The <a href="https://github.com/tl-its-umich-edu/student_explorer">GitHub repository</a> for Student Explorer
             is public. View <a href="https://github.com/tl-its-umich-edu/student_explorer/releases">release notes</a>
             for Student Explorer.

--- a/student_explorer/templates/student_explorer/index.html
+++ b/student_explorer/templates/student_explorer/index.html
@@ -51,10 +51,11 @@
                 </a>
                 </div>
                 <div id="navbar" class="navbar-collapse collapse">
+                    {% url 'about' as abouturl %}
                     {% url 'seumich:advisor' advisor.username as mystudentsurl%}
                     {% url 'seumich:advisors_list' as advisorsurl %}
                     <ul class="nav navbar-nav">
-                        <li class="active">
+                        <li {% if request.path == abouturl %} class="active" {% endif %}>
                             <a href="{% url 'about' %}">About</a>
                         </li>
                         <li {% if request.path == mystudentsurl %} class="active" {% endif %}>

--- a/student_explorer/templates/student_explorer/index.html
+++ b/student_explorer/templates/student_explorer/index.html
@@ -54,6 +54,9 @@
                     {% url 'seumich:advisor' advisor.username as mystudentsurl%}
                     {% url 'seumich:advisors_list' as advisorsurl %}
                     <ul class="nav navbar-nav">
+                        <li class="active">
+                            <a href="{% url 'about' %}">About</a>
+                        </li>
                         <li {% if request.path == mystudentsurl %} class="active" {% endif %}>
                             <a href="{% url 'seumich:index' %}" data-toggle="collapse" data-target="#navbar.in">My Students</a>
                         </li>
@@ -133,20 +136,21 @@
             {% block content %}{% endblock %}
             <footer>
                 <div class="container-fluid">
-                <div class='feedback center-align'>
-                    <a href="{% url 'feedback:feedback' %}">
-                        <button type="button" class="btn btn-sm btn-default">
-                            <img src="{% static 'seumich/images/feedback.svg' %}" alt="Feedback icon"></img>
-                            Submit Feedback</button>
-                    </a>
-                </div>
-                <div class="row main-color-white">
-                    <div class="col-xs-6 text-left"><a href="{% url 'about' %}" style="text-decoration: none; color: inherit;">Student Explorer </a>
-                        <span class="footer-block">Copyright &copy; 2015 - 2019</span>
-                        <span class="footer-block">The Regents of the University of Michigan</span>
+                    <div class='feedback center-align'>
+                        <a href="{% url 'feedback:feedback' %}">
+                            <button type="button" class="btn btn-sm btn-default">
+                                <img src="{% static 'seumich/images/feedback.svg' %}" alt="Feedback icon"></img>
+                                Submit Feedback</button>
+                        </a>
                     </div>
-                    <div class="col-xs-6 text-right">
-                            Data last updated from Canvas: {{ data_time|date:"m/d/Y P T"}} | Schema: {{data_schema}}
+                    <div class="row main-color-white">
+                        <div class="col-xs-6 text-left"><a href="{% url 'about' %}" style="text-decoration: none; color: inherit;">Student Explorer </a>
+                            <span class="footer-block">Copyright &copy; 2015 - 2019</span>
+                            <span class="footer-block">The Regents of the University of Michigan</span>
+                        </div>
+                        <div class="col-xs-6 text-right">
+                                Data last updated from Canvas: {{ data_time|date:"m/d/Y P T"}} | Schema: {{data_schema}}
+                        </div>
                     </div>
                 </div>
             </footer>


### PR DESCRIPTION
This PR adds a link to the About page to the navigation bar and expands the text on that page, using copy provided by @mfldavidson. This PR aims to resolve issues #86 and #138.

The headers on the About page are currently using `h2` tags with `class=header`. This option seemed preferable since the `h1` tag with `class=subheader` previously in use was resulting in rather large headers in bold red. I'd be happy to change or modify this; I'm not sure what's in use around the site. Other suggested changes to the text formatting are welcome.

The About page does not appear to require authentication to visit, if navigated to directly. This seems to be in line with the future approach suggested in issue #86, where we might want to redirect unauthenticated users to the page.