### PR TITLE
Rearranging navigation bar (#151)

### DIFF
--- a/student_explorer/templates/student_explorer/index.html
+++ b/student_explorer/templates/student_explorer/index.html
@@ -38,7 +38,7 @@
 
     <body>
         <nav class="navbar navbar-inverse navbar-fixed-top">
-            {% url 'seumich:advisor' advisor.username as mystudentsurl%}
+            {% url 'seumich:advisor' advisor.username as mystudentsurl %}
             {% url 'about' as abouturl %}
             {% url 'seumich:advisors_list' as advisorsurl %}
             {% url 'management:index' as manageurl %}

--- a/student_explorer/templates/student_explorer/index.html
+++ b/student_explorer/templates/student_explorer/index.html
@@ -38,6 +38,10 @@
 
     <body>
         <nav class="navbar navbar-inverse navbar-fixed-top">
+            {% url 'seumich:advisor' advisor.username as mystudentsurl%}
+            {% url 'about' as abouturl %}
+            {% url 'seumich:advisors_list' as advisorsurl %}
+            {% url 'management:index' as manageurl %}
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
@@ -46,23 +50,23 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                <a href="{% url 'seumich:index' %}">
+                <a href="{% url 'about' %}">
                     <span class="main-color-white main-navbar-brand navbar-brand"><img id="student-explorer-logo" src="/static/seumich/images/se-logo.svg" alt="student explorer logo">Student Explorer</span>
                 </a>
                 </div>
                 <div id="navbar" class="navbar-collapse collapse">
-                    {% url 'about' as abouturl %}
-                    {% url 'seumich:advisor' advisor.username as mystudentsurl%}
-                    {% url 'seumich:advisors_list' as advisorsurl %}
-                    <ul class="nav navbar-nav">
-                        <li {% if request.path == abouturl %} class="active" {% endif %}>
-                            <a href="{% url 'about' %}">About</a>
-                        </li>
+                    <form action="{% url 'seumich:students_list' %}" method="get" class="navbar-form navbar-left">
+                        <div class="form-group">
+                            <label for="student-search" class="sr-only">Search student name, uniqname, or UMID...</label>
+                            <input id="student-search" value="{{ query_user | default_if_none:'' }}" name="search" type="text" class="form-control" placeholder="Search student name, uniqname, or UMID...">
+                        </div>
+                    </form>
+                    <ul class="nav navbar-nav navbar-right">
                         <li {% if request.path == mystudentsurl %} class="active" {% endif %}>
                             <a href="{% url 'seumich:index' %}" data-toggle="collapse" data-target="#navbar.in">My Students</a>
                         </li>
-                        <li {% if request.path == advisorsurl %} class="active" {% endif %}>
-                            <a href="{% url 'seumich:advisors_list' %}" data-toggle="collapse" data-target="#navbar.in">Advisors</a>
+                        <li {% if request.path == abouturl %} class="active" {% endif %}>
+                            <a href="{% url 'about' %}">About</a>
                         </li>
                         <li>
                             <a href="https://documentation.its.umich.edu/node/831" target="_blank">
@@ -70,22 +74,22 @@
                                 <i class="fa fa-external-link" aria-hidden="true" width="25px" hspace="3" alt="External Help Doc Icon"></i>
                             </a>
                         </li>
-                    </ul>
-                    <ul class="nav navbar-nav navbar-right">
                         {% if user.is_authenticated %}
                             <li class="dropdown hidden-xs hidden-sm">
                                 <a class="dropdown-toggle" aria-label="expand for logout" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" href="">{{user.username}}
                                     <span class="caret"></span>
                                 </a>
                                 <ul class="dropdown-menu">
+                                    {% if user.first_name and user.last_name %}
                                     <li>
-                                        <p>
-                                            <strong>{{user.first_name}}
-                                                {{user.last_name}}</strong>
-                                        </p>
+                                        <p><strong>{{user.first_name}} {{user.last_name}}</strong></p>
                                     </li>
+                                    {% endif %}
                                     {% if user.is_superuser %}
-                                        <li>
+                                        <li {% if request.path == advisorsurl %} class="active" {% endif %}>
+                                            <a href="{% url 'seumich:advisors_list' %}">Advisors</a>
+                                        </li>
+                                        <li {% if request.path == manageurl %} class="active" {% endif %}>
                                             <a href="{% url 'management:index' %}">Manage</a>
                                         </li>
                                     {% endif %}
@@ -97,9 +101,7 @@
                             </li>
                             <li class="visible-xs visible-sm">
                                 <p class="mobile-nav-right">
-                                    <strong>{{user.first_name}}
-                                        {{user.last_name}}
-                                        ({{user.username}})</strong>
+                                    <strong>{{user.first_name}} {{user.last_name}} ({{user.username}})</strong>
                                 </p>
                             </li>
                             <li class="visible-xs visible-sm">
@@ -111,12 +113,6 @@
                             </li>
                         {% endif %}
                     </ul>
-                    <form action="{% url 'seumich:students_list' %}" method="get" class="navbar-form navbar-right">
-                        <div class="form-group">
-                            <label for="student-search" class="sr-only">Search student name, uniqname, or UMID...</label>
-                            <input id="student-search" value="{{ query_user | default_if_none:'' }}" name="search" type="text" class="form-control" placeholder="Search student name, uniqname, or UMID...">
-                        </div>
-                    </form>
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
This PR makes changes to `index.html` to modify the navigation bar as requested by @mfldavidson. In general, it makes the search bar more prominent while simplifying the other tabs and options. Some additional details on the changes are provided below. The PR aims to resolve issue #151.

1) I changed the link for the Student Explorer logo to direct to the "About" page, which will serve as a quasi-landing page for the time being. Note that the root route (`/`) route directs the current user to their "My Students" tab, or the `All Advisors` page if the advisor does not have a record in the `DM_MNTR` table. We will be addressing this behavior as part of a separate issue.

2) In order to make the search bar more prominent, I moved the `form` element up and modified an existing class to be `navbar-left`, resulting in the field appearing directly to the right of the Student Explorer logo.

3) As requested, the "Advisors" link was moved to the drop-down menu above "Manage". Both "Advisors" and "Manage" links are only visible to superusers. The `advisors/` route and advisor-specific routes (e.g. `advisor/ssciolla`) are still accessible directly for authenticated users. I also added some conditional handling so that both the "Advisors" and "Manage" links are highlighted in the drop-down menu when the user is on those pages.

4) The remaining links in the navigation bar ("My Students", "About", and "Resources & Support") were all moved to the right by grouping them with the drop-down menu in a `ul` with the`navbar-right` `class`.

5) I added an `if` template block to the presentation of a user's name in the drop-down menu so that it is only included when the user has a `first_name` and `last_name` in the database. This prevents some unneeded white space when the user does not have one of those values (which is the case for "admin").

6. The `url` declarations used for active link highlighting on the bar were grouped together at the beginning of the content nested under the parent `nav` element. White space was also removed from some elements to improve the file's overall readability.