### PR TITLE
Updating About page based on revisions (#86)

### DIFF
--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -3,35 +3,38 @@
 {% block content %}
     <div class="container content">
         <h1 class="sub-header">About Student Explorer</h1>
-        <p>Student Explorer is an early warning system that leverages Learning Management System data to <b>help
-            academic advisors identify at-risk students.</b> It uses learning analytics techniques to create actionable
-            intelligence that assists academic advisors in identifying students at risk of academic jeopardy in order to
-            facilitate outreach to these students. The tool helps advisors create timely interventions to direct
-            students toward resources or behavioral changes that help facilitate future student success. Student
-            Explorer is available to <b>all academic advisors at the U-M Ann Arbor campus upon request for access</b>
-            and includes information about <b>all students on the Ann Arbor campus, including graduate students.</b> For
-            more information about how Student Explorer works and how to use it, please refer to the
-            <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>.
+        <p>Student Explorer is an early warning system that <b>helps academic advisors identify at-risk students</b>
+            based on current term Learning Management System data. Using visualizations of data about students' current
+            term grades and assignments, it presents actionable intelligence to academic advisors. By helping them
+            identify students at risk of academic jeopardy, the tool enables advisors to create timely interventions
+            directing students toward resources that may facilitate behavioral change and academic growth and success.
+            For more information about how Student Explorer works and how to use it, please refer to the
+            <a href="https://documentation.its.umich.edu/student-explorer-general">Student Explorer documentation</a>.
+        </p>
+
+        <h2 class="list-header">Student Explorer Access</h2>
+        <p>Student Explorer is available to all professional staff/faculty advisors at the U-M Ann Arbor campus upon
+            request for access and includes information about all students on the Ann Arbor campus, including graduate
+            students. Students, including peer advisors, are not able to gain access to Student Explorer.
         </p>
 
         <h2 class="list-header">About Cohorts</h2>
-        <p>Student Explorer operates using a cohort model; students are assigned to advisors using cohorts so that
-            advisors can see all of their students in their <a href="/">"My Students" tab</a>. <b>You do not need to
-            have cohorts in order to use Student Explorer</b> &#151; you can search for students individually using the
-            search bar in the upper right, or navigate to an individual student's page using the link under "Term
-            Progress" in the LSA Undergraduate Student Advising File. However, if you would like to set up a cohort to
-            see all of your students in one list, please follow the instructions in the
-            <a href="https://documentation.its.umich.edu/node/831">Student Explorer documentation</a>. <b>Cohorts are
-            not connected to advisor assignments in Wolverine Access or the LSA Undergraduate Student Advising
-            File.</b>
+        <p>You can set up one or more lists of students, called "cohorts," so you can view all your students on your
+            <a href="/">"My Students" page</a>. You do not need to have students assigned to you through a cohort to
+            use Student Explorer. <a href="https://documentation.its.umich.edu/student-explorer-cohorts">Learn more
+                about cohorts and how to create them.</a>
         </p>
 
         <h2 class="list-header">Student Explorer History</h2>
-        <p>Student Explorer was started as a research project in 2011 led by Professor Stephanie Teasley and Dr. Steven
+        <p>Student Explorer started in 2011 as a research project led by Professor Stephanie Teasley and Dr. Steven
             Lonn in partnership with M-STEM Academies. LSA Technology Services, Academic Innovation, and ITS Teaching &
-            Learning have contributed to the design, development, and management of the tool. Student Explorer is
-            currently run by ITS Teaching & Learning, and <b>questions and comments can be directed to the team by
-            <a href="/feedback">submitting feedback</a>.</b>
+            Learning have contributed to the design, development, and management of the tool.
+        </p>
+
+        <h2 class="list-header">Contact the Student Explorer Team</h2>
+        <p>ITS Teaching & Learning manages Student Explorer; the Service Manager is
+            <a href="https://mcommunity.umich.edu/#profile:jmaggie" target="_blank">Maggie Davidson</a>. Get in touch by
+            <a href="/feedback">submitting feedback</a>!
         </p>
 
         <hr/>


### PR DESCRIPTION
This PR makes changes to the text of the About page based on revisions in a separate Google document by myself and @mfldavidson. Most significantly, they include a reworking of the text under "About Student Explorer" and the splitting of other content into new sections. This PR aims to resolve issue #86.