### PR TITLE
Improving application's handling of new advisors (#139)

### DIFF
--- a/seumich/templates/seumich/student_list_partial.html
+++ b/seumich/templates/seumich/student_list_partial.html
@@ -4,8 +4,8 @@
 <script src='{% static 'seumich/sort_table.js' %}'></script>
 
 <h1 class="sub-header">{{ studentListHeader }}</h1>
+<hr class="main-no-margin-top"/>
 {% if students %}
-    <hr class="main-no-margin-top"/>
     <h2 class="list-header">Students</h2>
 {% endif %}
 

--- a/seumich/urls.py
+++ b/seumich/urls.py
@@ -17,29 +17,22 @@ from django.conf.urls import url
 from seumich import views
 
 urlpatterns = [
-    url(
-        r'^$',
+    url(r'^$',
         views.IndexView.as_view(),
         name='index'),
-
-    url(
-        r'^advisors/$',
+    url(r'^advisors/$',
         views.AdvisorsListView.as_view(),
         name='advisors_list'),
-    url(
-        r'^cohorts/$',
+    url(r'^cohorts/$',
         views.CohortsListView.as_view(),
         name='cohorts_list'),
-    url(
-        r'^advisors/(?P<advisor>[\s\w-]+)/$',
+    url(r'^advisors/(?P<advisor>[\s\w-]+)/$',
         views.AdvisorView.as_view(),
         name='advisor'),
-    url(
-        r'^cohorts/(?P<code>[\s\w-]+)/$',
+    url(r'^cohorts/(?P<code>[\s\w-]+)/$',
         views.CohortView.as_view(),
         name='cohort'),
-    url(
-        r'^classes/(?P<class_site_id>\d+)/$',
+    url(r'^classes/(?P<class_site_id>\d+)/$',
         views.ClassSiteView.as_view(),
         name='class_site'),
     url(r'^students/$',

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -8,18 +8,18 @@ from django.shortcuts import get_object_or_404, redirect
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db.models import Q, Prefetch, Value as V
 from django.db.models.functions import Concat
+from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
-from django.conf import settings
 from tracking.utils import UserLogPageViewMixin
 
 import operator
 import logging
 
-from django.conf import settings
 from decouple import config
 from functools import reduce
 
+User = get_user_model()
 logger = logging.getLogger(__name__)
 
 class AdvisorsListView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
@@ -93,22 +93,30 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     template_name = 'seumich/advisor_detail.html'
     context_object_name = 'students'
 
+    def get_queryset(self):
+        self.mentor = None
+        try:
+            self.mentor = Mentor.objects.get(username=self.kwargs['advisor'])
+            student_list = self.mentor.students.order_by('last_name').distinct()
+            student_list = student_list.prefetch_related(
+                'studentclasssitestatus_set__status',
+                'studentclasssitestatus_set__class_site',
+                'cohorts'
+            )
+        except ObjectDoesNotExist:
+            student_list = []
+        return student_list
+
     def get_context_data(self, **kwargs):
         context = super(AdvisorView, self).get_context_data(**kwargs)
-        context['studentListHeader'] = self.mentor.first_name + \
-            " " + self.mentor.last_name
-        context['advisor'] = self.mentor
+        user = User.objects.get(username=self.kwargs['advisor'])
+        if self.mentor is not None:
+            context['studentListHeader'] = " ".join([self.mentor.first_name, self.mentor.last_name])
+            context['advisor'] = self.mentor
+        else:
+            context['studentListHeader'] = " ".join([user.first_name, user.last_name])
+            context['advisor'] = user
         return context
-
-    def get_queryset(self):
-        self.mentor = get_object_or_404(Mentor,
-                                        username=self.kwargs['advisor'])
-        student_list = self.mentor.students.order_by('last_name').distinct()
-        student_list = student_list.prefetch_related(
-            'studentclasssitestatus_set__status',
-            'studentclasssitestatus_set__class_site',
-            'cohorts')
-        return student_list
 
 
 class CohortView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
@@ -159,13 +167,6 @@ class ClassSiteView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
 class IndexView(LoginRequiredMixin, UserLogPageViewMixin, View):
 
     def get(self, request):
-        # If the user has no mentors (is an admin) just redirect to main list
-        try:
-            has_mentor = Mentor.objects.get(username=request.user.username)
-        except Mentor.DoesNotExist:
-            logger.info('(%s) not found as mentor. Redirecting to advisors_list'
-                            % request.user.username)
-            return redirect('seumich:advisors_list')
         return redirect('seumich:advisor', advisor=request.user.username)
 
 

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -108,7 +108,7 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
         self.mentor = None
         try:
             self.mentor = Mentor.objects.get(username=self.kwargs['advisor'])
-            student_list = self.mentor.students.order_by('last_name').distinct()
+            student_list = self.mentor.students.filter(id__gt=0).order_by('last_name').distinct()
             student_list = student_list.prefetch_related(
                 'studentclasssitestatus_set__status',
                 'studentclasssitestatus_set__class_site',
@@ -116,6 +116,7 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
             )
         except ObjectDoesNotExist:
             student_list = []
+        logger.debug(student_list)
         return student_list
 
 

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -108,7 +108,7 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
         self.mentor = None
         try:
             self.mentor = Mentor.objects.get(username=self.kwargs['advisor'])
-            student_list = self.mentor.students.filter(id__gt=0).order_by('last_name').distinct()
+            student_list = self.mentor.students.filter(id__gte=0).order_by('last_name').distinct()
             student_list = student_list.prefetch_related(
                 'studentclasssitestatus_set__status',
                 'studentclasssitestatus_set__class_site',

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -93,6 +93,17 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     template_name = 'seumich/advisor_detail.html'
     context_object_name = 'students'
 
+    def get_context_data(self, **kwargs):
+        context = super(AdvisorView, self).get_context_data(**kwargs)
+        user = User.objects.get(username=self.kwargs['advisor'])
+        if self.mentor is not None:
+            context['studentListHeader'] = " ".join([self.mentor.first_name, self.mentor.last_name])
+            context['advisor'] = self.mentor
+        else:
+            context['studentListHeader'] = " ".join([user.first_name, user.last_name])
+            context['advisor'] = user
+        return context
+
     def get_queryset(self):
         self.mentor = None
         try:
@@ -106,17 +117,6 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
         except ObjectDoesNotExist:
             student_list = []
         return student_list
-
-    def get_context_data(self, **kwargs):
-        context = super(AdvisorView, self).get_context_data(**kwargs)
-        user = User.objects.get(username=self.kwargs['advisor'])
-        if self.mentor is not None:
-            context['studentListHeader'] = " ".join([self.mentor.first_name, self.mentor.last_name])
-            context['advisor'] = self.mentor
-        else:
-            context['studentListHeader'] = " ".join([user.first_name, user.last_name])
-            context['advisor'] = user
-        return context
 
 
 class CohortView(LoginRequiredMixin, UserLogPageViewMixin, ListView):

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -19,8 +19,8 @@ import logging
 from decouple import config
 from functools import reduce
 
-User = get_user_model()
 logger = logging.getLogger(__name__)
+
 
 class AdvisorsListView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     template_name = 'seumich/advisor_list.html'
@@ -95,7 +95,7 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(AdvisorView, self).get_context_data(**kwargs)
-        user = User.objects.get(username=self.kwargs['advisor'])
+        user = get_user_model().objects.get(username=self.kwargs['advisor'])
         if self.mentor is not None:
             context['studentListHeader'] = " ".join([self.mentor.first_name, self.mentor.last_name])
             context['advisor'] = self.mentor


### PR DESCRIPTION
Inspired by past conversations with @mfldavidson and a solution suggested yesterday by @jonespm, this PR primarily makes changes to the `AdvisorView` and `IndexView` classes in order to improve the user experience of advisors new to Student Explorer. More details about the changes are provided below. This PR aims to resolve #139.

1) Previously, a `try/except` clause was used in `IndexView` to either redirect users to their "My Students" page or redirect them to the "All Advisors" page (if the particular user did not have a Mentor model instance with a matching username). I deleted the bulk of the clause so that all users are redirected to their "My Students" page, which uses the `/advisors/{username}` route pattern.

2) In the `AdvisorView` class, both the `get_queryset` and `get_context_data` methods were updated. Now `get_queryset` will try to find a `Mentor` model instance associated with the user's `username`. If the attempt succeeds, the application will return a QuerySet of students associated with the advisor. If the attempt fails, an empty list will be returned, ultimately resulting in an empty table on the front end. I also changed `get_context_data` so that (depending on whether a Mentor object was found and set to `self.mentor` in `get_queryset`) a context dictionary will be returned with either the name info from the Mentor object or the User object. I opted to use a `" ".join()" over concatenation to prepare advisors' full names, as that seems to more cleanly handle missing name values.

3) A small change was made to the `student_list_partial.html` template so that a `hr` tag (a shaded line break) always appears under the advisor's name, regardless of whether the advisor has any associated students. If the advisor has no students, an empty table is currently shown; this will be addressed in a future pull request addressing issue #140.

4) I modified the line spacing of the `urlpatterns` variable of `seumich/urls.py` to be more consistent. I also removed unnecessary imports to `django.conf.settings`.