### PR TITLE
Adding new template that appears for advisors with no students (#140)

### DIFF
--- a/seumich/static/seumich/styles/main.scss
+++ b/seumich/static/seumich/styles/main.scss
@@ -728,7 +728,7 @@ svg {
 .content {
     margin-bottom: 100px;
 }
-.advisor-intro-text {
+.advisor-intro-lead-text {
     font-size: 18px;
 }
 .advisor-intro-column {

--- a/seumich/static/seumich/styles/main.scss
+++ b/seumich/static/seumich/styles/main.scss
@@ -728,3 +728,10 @@ svg {
 .content {
     margin-bottom: 100px;
 }
+.advisor-intro-text {
+    font-size: 18px;
+}
+.advisor-intro-column {
+    padding-top: 16px;
+    padding-bottom: 16px;
+}

--- a/seumich/templates/seumich/advisor_detail.html
+++ b/seumich/templates/seumich/advisor_detail.html
@@ -2,8 +2,6 @@
 
 {% block content %}
     <div class="container content">
-        <h1 class="sub-header">{{ studentListHeader }}</h1>
-        <hr class="main-no-margin-top"/>
         {% if advisor %}
             {% if advisor.username == user.username and not students %}
                 {% include 'seumich/advisor_without_students.html' %}

--- a/seumich/templates/seumich/advisor_detail.html
+++ b/seumich/templates/seumich/advisor_detail.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="container content">
         {% if advisor %}
-            {% if advisor.username == user.username and not students %}
+            {% if not students %}
                 {% include 'seumich/advisor_without_students.html' %}
             {% else %}
                 {% include 'seumich/student_list_partial.html' %}

--- a/seumich/templates/seumich/advisor_detail.html
+++ b/seumich/templates/seumich/advisor_detail.html
@@ -2,8 +2,14 @@
 
 {% block content %}
     <div class="container content">
+        <h1 class="sub-header">{{ studentListHeader }}</h1>
+        <hr class="main-no-margin-top"/>
         {% if advisor %}
-            {% include 'seumich/student_list_partial.html' %}
+            {% if advisor.username == user.username and not students %}
+                {% include 'seumich/advisor_without_students.html' %}
+            {% else %}
+                {% include 'seumich/student_list_partial.html' %}
+            {% endif %}
         {% else %}
             <div class="panel panel-warning not-found">
                 <div class="panel-heading">

--- a/seumich/templates/seumich/advisor_without_students.html
+++ b/seumich/templates/seumich/advisor_without_students.html
@@ -1,13 +1,11 @@
 {% block content %}
-    <div>
-        <h2 class="list-header">Welcome to Student Explorer!</h2>
-        <p class="advisor-intro-text">Student Explorer helps academic advisors identify academically at-risk
-            students using Learning Management System data.
-        </p>
-    </div>
+    <h2 class="list-header">Welcome to Student Explorer!</h2>
+    <p class="advisor-intro-lead-text">Student Explorer helps academic advisors identify academically at-risk
+        students using Learning Management System data.
+    </p>
     <div class="row">
         <div class="col-sm-4 advisor-intro-column">
-            <i class="fa fa-search fa-3x advisor-intro-icon"></i>
+            <i class="fa fa-search fa-3x"></i>
             <h2 class="list-header" style="margin-top: 20px">Search for any student</h2>
             <p>Type the student's name, uniqname, or UMID in the search bar above to explore their academic
                 performance. You can find any U-M Ann Arbor student, including graduate students, in Student
@@ -15,7 +13,7 @@
             </p>
         </div>
         <div class="col-sm-4 advisor-intro-column">
-            <i class="fa fa-user-plus fa-3x advisor-intro-icon"></i>
+            <i class="fa fa-user-plus fa-3x"></i>
             <h2 class="list-header" style="margin-top: 20px">Create your student list</h2>
             <p>Want to see a list of your students all in one place? Student Explorer lets you view a list of your
                 students, called a "cohort," for quick and easy reference.
@@ -24,7 +22,7 @@
             </p>
         </div>
         <div class="col-sm-4 advisor-intro-column">
-            <i class="fa fa-info-circle fa-3x advisor-intro-icon"></i>
+            <i class="fa fa-info-circle fa-3x"></i>
             <h2 class="list-header" style="margin-top: 20px">Learn more</h2>
             <p>Visit our <a href="/about/">About page</a> to learn more about the purpose and history of Student
                 Explorer, or visit <a href="https://documentation.its.umich.edu/node/831">Resources & Support</a>

--- a/seumich/templates/seumich/advisor_without_students.html
+++ b/seumich/templates/seumich/advisor_without_students.html
@@ -1,4 +1,6 @@
 {% block content %}
+    <h1 class="sub-header">{{ studentListHeader }}</h1>
+    <hr class="main-no-margin-top"/>
     <h2 class="list-header">Welcome to Student Explorer!</h2>
     <p class="advisor-intro-lead-text">Student Explorer helps academic advisors identify academically at-risk
         students using Learning Management System data.

--- a/seumich/templates/seumich/advisor_without_students.html
+++ b/seumich/templates/seumich/advisor_without_students.html
@@ -1,0 +1,35 @@
+{% block content %}
+    <div>
+        <h2 class="list-header">Welcome to Student Explorer!</h2>
+        <p class="advisor-intro-text">Student Explorer helps academic advisors identify academically at-risk
+            students using Learning Management System data.
+        </p>
+    </div>
+    <div class="row">
+        <div class="col-sm-4 advisor-intro-column">
+            <i class="fa fa-search fa-3x advisor-intro-icon"></i>
+            <h2 class="list-header" style="margin-top: 20px">Search for any student</h2>
+            <p>Type the student's name, uniqname, or UMID in the search bar above to explore their academic
+                performance. You can find any U-M Ann Arbor student, including graduate students, in Student
+                Explorer.
+            </p>
+        </div>
+        <div class="col-sm-4 advisor-intro-column">
+            <i class="fa fa-user-plus fa-3x advisor-intro-icon"></i>
+            <h2 class="list-header" style="margin-top: 20px">Create your student list</h2>
+            <p>Want to see a list of your students all in one place? Student Explorer lets you view a list of your
+                students, called a "cohort," for quick and easy reference.
+                <a href="https://documentation.its.umich.edu/student-explorer-cohorts">Learn more about cohorts and
+                how to set one up.</a>
+            </p>
+        </div>
+        <div class="col-sm-4 advisor-intro-column">
+            <i class="fa fa-info-circle fa-3x advisor-intro-icon"></i>
+            <h2 class="list-header" style="margin-top: 20px">Learn more</h2>
+            <p>Visit our <a href="/about/">About page</a> to learn more about the purpose and history of Student
+                Explorer, or visit <a href="https://documentation.its.umich.edu/node/831">Resources & Support</a>
+                for information on how to use Student Explorer.
+            </p>
+        </div>
+    </div>
+{% endblock %}

--- a/seumich/templates/seumich/student_list_partial.html
+++ b/seumich/templates/seumich/student_list_partial.html
@@ -4,11 +4,7 @@
 {% cache settings.CACHE_TTL student_list_partial request.get_full_path %}
 <script src='{% static 'seumich/sort_table.js' %}'></script>
 
-<h1 class="sub-header">{{ studentListHeader }}</h1>
-<hr class="main-no-margin-top"/>
-{% if students %}
-    <h2 class="list-header">Students</h2>
-{% endif %}
+<h2 class="list-header">Students</h2>
 
 <div class="table-responsive">
     <table class="table table-striped">

--- a/seumich/templates/seumich/student_list_partial.html
+++ b/seumich/templates/seumich/student_list_partial.html
@@ -4,6 +4,8 @@
 {% cache settings.CACHE_TTL student_list_partial request.get_full_path %}
 <script src='{% static 'seumich/sort_table.js' %}'></script>
 
+<h1 class="sub-header">{{ studentListHeader }}</h1>
+<hr class="main-no-margin-top"/>
 <h2 class="list-header">Students</h2>
 
 <div class="table-responsive">

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -35,6 +35,7 @@ class CohortsListView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     queryset = Cohort.objects.filter(id__gte=0)
     context_object_name = 'cohorts'
 
+
 class StudentsListView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     template_name = 'seumich/student_list.html'
     context_object_name = 'students'

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -35,7 +35,6 @@ class CohortsListView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     queryset = Cohort.objects.filter(id__gte=0)
     context_object_name = 'cohorts'
 
-
 class StudentsListView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
     template_name = 'seumich/student_list.html'
     context_object_name = 'students'


### PR DESCRIPTION
This PR primarily adds a new template and CSS classes and presents that content to advisors without students (rather than an empty table) so they have guidance on getting started with Student Explorer. More details on the changes are provided below. The PR aims to resolve issue #140.

1) A new template fragment called `advisor_without_students.html` was added to `seumich/templates`. Based on a wireframe provided by UX staff in ITS, the template uses the Bootstrap grid system and includes content provided by @mfldavidson and Font Awesome icons. To control the font size of the introductory text and spacing between elements, I added two new CSS classes to `seumich/static/styles/main.scss`. The below image gives an example of the page.

![Screen Shot 2019-10-07 at 3 58 41 PM](https://user-images.githubusercontent.com/35741256/66345030-296f6380-e91d-11e9-87cd-0d1653192526.png)

2) Some changes were made to the `advisor_detail` and `student_list_partial` templates to control when the new template is presented and enhance consistency. In `advisor_detail`, I added an `if` block; if the advisor and user are the same and they are not related to any students, the new template is displayed, otherwise the usual table is rendered. This logic means that if you are logged in as one user and navigate to the route of another user that has no students, an empty table will be displayed. @mfldavidson is thinking about whether she agrees with this approach. If not, we can simplify the condition to only `if students`. I also moved the advisor's name and `hr` tag line to `advisor_detail` so it appears in both cases, and changed `student_list_partial` so the "Students" header appears even when the table is empty.