### PR TITLE
Improving coverage of different AdvisorView cases and adding tests (#165)

### DIFF
--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -562,10 +562,6 @@ class SeumichTest(TestCase):
         students = list(response.context['students'].values('username', 'first_name', 'last_name'))
         self.assertCountEqual(expected_students, students)
         # Clean up
-        user_lavera = get_user_model().objects.create(
-            username="lavera", first_name="Lavera", last_name="Rumore"
-        )
-        user_lavera.set_password("lavera")
         user_lavera.save()
 
     def test_student_view_redirect(self):

--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -48,7 +48,10 @@ class SeumichTest(TestCase):
     def setUp(self):
         self.client = Client()
         os.system((
-            f"mysql -h {settings.DATABASES['default']['HOST']} -u {settings.DATABASES['default']['USER']} -p{settings.DATABASES['default']['PASSWORD']} test_student_explorer < seumich/fixtures/dev_data_drop_create_and_insert.sql"
+            f"mysql -h {settings.DATABASES['default']['HOST']} "
+            f"-u {settings.DATABASES['default']['USER']} "
+            f"-p{settings.DATABASES['default']['PASSWORD']} "
+            f"test_student_explorer < seumich/fixtures/dev_data_drop_create_and_insert.sql"
         ))
 
     def test_from_db_value(self):
@@ -525,7 +528,7 @@ class SeumichTest(TestCase):
         self.assertContains(response, 'james')
         self.assertNotContains(response, 'grace')
 
-    def test_advisor_user_without_mentor(self):
+    def test_advisor_view_user_without_mentor(self):
         # Set up
         user_ebenezer = get_user_model().objects.create(
             username="ebenezer", first_name="Ebenezer", last_name="Scrooge"
@@ -542,7 +545,7 @@ class SeumichTest(TestCase):
         # Clean up
         user_ebenezer.delete()
 
-    def test_advisor_mentor_without_user(self):
+    def test_advisor_view_mentor_without_user(self):
         # Set up
         expected_students = [
             {'username': 'james', 'first_name': 'James', 'last_name': 'Bond'},

--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -1,9 +1,9 @@
 import os
-from django.test import TestCase
 from django.conf import settings
-from django.test.client import Client
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.client import Client
 from seumich.models import (UsernameField,
                             Advisor,
                             Date,

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -99,9 +99,13 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
             context['studentListHeader'] = " ".join([self.mentor.first_name, self.mentor.last_name])
             context['advisor'] = self.mentor
         else:
-            user = get_user_model().objects.get(username=self.kwargs['advisor'])
-            context['studentListHeader'] = " ".join([user.first_name, user.last_name])
-            context['advisor'] = user
+            try:
+                user = get_user_model().objects.get(username=self.kwargs['advisor'])
+                context['studentListHeader'] = " ".join([user.first_name, user.last_name])
+                context['advisor'] = user
+            except ObjectDoesNotExist:
+                context['studentListHeader'] = ''
+                context['advisor'] = None
         return context
 
     def get_queryset(self):

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -120,7 +120,6 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
             )
         except ObjectDoesNotExist:
             student_list = []
-        logger.info(student_list)
         return student_list
 
 

--- a/seumich/views.py
+++ b/seumich/views.py
@@ -95,11 +95,11 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(AdvisorView, self).get_context_data(**kwargs)
-        user = get_user_model().objects.get(username=self.kwargs['advisor'])
         if self.mentor is not None:
             context['studentListHeader'] = " ".join([self.mentor.first_name, self.mentor.last_name])
             context['advisor'] = self.mentor
         else:
+            user = get_user_model().objects.get(username=self.kwargs['advisor'])
             context['studentListHeader'] = " ".join([user.first_name, user.last_name])
             context['advisor'] = user
         return context
@@ -116,7 +116,7 @@ class AdvisorView(LoginRequiredMixin, UserLogPageViewMixin, ListView):
             )
         except ObjectDoesNotExist:
             student_list = []
-        logger.debug(student_list)
+        logger.info(student_list)
         return student_list
 
 


### PR DESCRIPTION
This PR primarily fixes a bug found by @jonespm in the test instance of Student Explorer that resulted in broken links when an advisor had a `Mentor` record but not a `User` record. The logic of `AdvisorView` was updated to handle this case, as well as when neither a `Mentor` or `User` record exist. Two tests were also added to `tests.py` to cover cases where one record exists but not the other. More details are provided below. The PR aims to resolve issue #165.

1) The major change of this PR is to modify the `get_context_data` method of `AdvisorView`. I moved the line attempting to fetch an advisor's `User` record to under the existing `else` clause, so that in cases when a `Mentor` record exists but not a `User record`, only the `Mentor` lookup happens. I then enclosed the `user` related code in a `try` clause, and added an `except` that assigns null values when a `user` lookup fails. This means that the `else` template block of `advisor_detail` would be actually used (because `if advisor` returns `False`), resulting in a clean "No advisor profile found" message rather than a `404` error.

2) I also added two new test cases to `seumich/tests.py`. The `test_advisor_view_user_without_mentor` case first creates a new mock user `ebenezer`, logs in as that user, and then checks the response to the `advisors/ebenezer` request to ensure the user's name ("Ebenezer Scrooge") and an empty `students` list are included. The case `test_advisor_view_mentor_without_user` first deletea the preexisting mock user `lavera`, logs in with another user, tests to make sure the correct data is still returned from the `advisors/lavera` request (since the `Mentor` object still exists), and then recreates the user.