### PR TITLE
Moving if not students check from advisor_detail to student_list_partial template

### DIFF
--- a/seumich/templates/seumich/advisor_detail.html
+++ b/seumich/templates/seumich/advisor_detail.html
@@ -3,11 +3,7 @@
 {% block content %}
     <div class="container content">
         {% if advisor %}
-            {% if not students %}
-                {% include 'seumich/advisor_without_students.html' %}
-            {% else %}
-                {% include 'seumich/student_list_partial.html' %}
-            {% endif %}
+            {% include 'seumich/student_list_partial.html' %}
         {% else %}
             <div class="panel panel-warning not-found">
                 <div class="panel-heading">

--- a/seumich/templates/seumich/student_list_partial.html
+++ b/seumich/templates/seumich/student_list_partial.html
@@ -4,108 +4,111 @@
 {% cache settings.CACHE_TTL student_list_partial request.get_full_path %}
 <script src='{% static 'seumich/sort_table.js' %}'></script>
 
-<h1 class="sub-header">{{ studentListHeader }}</h1>
-<hr class="main-no-margin-top"/>
-<h2 class="list-header">Students</h2>
+{% if advisor and not students %}
+    {% include 'seumich/advisor_without_students.html' %}
+{% else %}
+    <h1 class="sub-header">{{ studentListHeader }}</h1>
+    <hr class="main-no-margin-top"/>
+    <h2 class="list-header">Students</h2>
 
-<div class="table-responsive">
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th scope="col" class="hide-small">
-                    <strong class="table-column-name">First Name</strong>
-                </th>
-                <th scope="col" class="hide-small">
-                    <strong class="table-column-name">Last Name</strong>
-                </th>
-                 <th scope="col" class="hide-small">
-                    <strong class="table-column-name">Uniqname</strong>
-                </th>
-                <th scope="col" class="hide-small sorter-digit">
-                    <strong class="table-column-name">Student ID</strong>
-                </th>
-                <th scope="col" class="hide-small sorter-digit" data-filter="false" data-sortinitialorder="desc">
-                    <strong class="table-column-name">Status</strong>
-                </th>
-                <th scope="col" class="hide-small" data-sorter="false">
-                    <strong class="table-column-name">Cohorts</strong>
-                </th>
-            </tr>
-        </thead>
-        <tfoot>
-            <tr>
-                <th scope="col" class="hide-small">
-                    <strong class="table-column-name">First Name</strong>
-                </th>
-                <th scope="col" class="hide-small">
-                    <strong class="table-column-name">Last Name</strong>
-                </th>
-                 <th scope="col" class="hide-small">
-                    <strong class="table-column-name">Uniqname</strong>
-                </th>
-                <th scope="col" class="hide-small">
-                    <strong class="table-column-name">Student ID</strong>
-                </th>
-                <th scope="col" class="hide-small" data-sorter="false">
-                    <strong class="table-column-name">Status</strong>
-                </th>
-                <th scope="col" class="hide-small" data-sorter="false">
-                    <strong class="table-column-name">Cohorts</strong>
-                </th>
-            </tr>
-            <tr>
-                {% include 'seumich/ts_pager.html' with colspan="6" %}
-            </tr>
-        </tfoot>
-        <tbody>
-            {% for student in students %}
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
                 <tr>
-                    <td scope="row" class="bold">
-                        <a href="{% url 'seumich:student' student.username %}">{{ student.first_name }}</a>
-                    </td>
-                    <td scope="row" class="bold">
-                        <a href="{% url 'seumich:student' student.username %}">{{ student.last_name }}</a>
-                    </td>
-                     <td scope="row" class="bold">
-                        <a href="{% url 'seumich:student' student.username %}">{{ student.username }}</a>
-                    </td>
-                    <td class="hide-small">{{ student.univ_id }}</td>
-                    <td data-text="{{student.status_calculated_value}}">
-                        {% for element in student.studentclasssitestatus_set.all %}
-                            {% with class_site=element.class_site %}
-                            <a href="{% url 'seumich:student_class' student.username class_site.code %}" class="class-site-status-link">
-                                {% with status=element.status %}
-                                {% if status.description == 'Green' %}
-                                    <span data-toggle="tooltip" title="{{ class_site.description }}: Encourage" data-placement="bottom">
-                                        <img src="{% static 'seumich/images/Status_Icons_Green.png' %}" alt="Green encourage status icon" width="25px" hspace="3"></img>
-                                    </span>
-                                {% elif status.description == 'Yellow' %}
-                                    <span data-toggle="tooltip" title="{{ class_site.description }}: Explore" data-placement="bottom">
-                                        <img src="{% static 'seumich/images/Status_Icons_Yellow.png' %}" alt="Yellow explore status icon" width="25px" hspace="3"></img>
-                                    </span>
-                                {% elif status.description == 'Red' %}
-                                    <span data-toggle="tooltip" title="{{ class_site.description }}: Engage" data-placement="bottom">
-                                        <img src="{% static 'seumich/images/Status_Icons_Red.png' %}" alt="Red engage status icon" width="25px" hspace="3"></img>
-                                    </span>
-                                {% elif status.description == 'Not Applicable' %}
-                                    <span data-toggle="tooltip" title="{{ class_site.description }}: No data" data-placement="bottom">
-                                        <img src="{% static 'seumich/images/Status_Icons_Not Applicable.png' %}" alt="no status available for this course icon" width="25px" hspace="3"></img>
-                                    </span>
-                                {% endif %}
-                                {% endwith %}
-                            </a>
-                            {% endwith %}
-                        {% endfor %}
-                    </td>
-                    <td class="hide-small">
-                        {% for cohort in student.cohorts.all %}
-                            <div>{{ cohort }}</div>
-                        {% endfor %}
-                    </td>
+                    <th scope="col" class="hide-small">
+                        <strong class="table-column-name">First Name</strong>
+                    </th>
+                    <th scope="col" class="hide-small">
+                        <strong class="table-column-name">Last Name</strong>
+                    </th>
+                     <th scope="col" class="hide-small">
+                        <strong class="table-column-name">Uniqname</strong>
+                    </th>
+                    <th scope="col" class="hide-small sorter-digit">
+                        <strong class="table-column-name">Student ID</strong>
+                    </th>
+                    <th scope="col" class="hide-small sorter-digit" data-filter="false" data-sortinitialorder="desc">
+                        <strong class="table-column-name">Status</strong>
+                    </th>
+                    <th scope="col" class="hide-small" data-sorter="false">
+                        <strong class="table-column-name">Cohorts</strong>
+                    </th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-
-</div>
+            </thead>
+            <tfoot>
+                <tr>
+                    <th scope="col" class="hide-small">
+                        <strong class="table-column-name">First Name</strong>
+                    </th>
+                    <th scope="col" class="hide-small">
+                        <strong class="table-column-name">Last Name</strong>
+                    </th>
+                     <th scope="col" class="hide-small">
+                        <strong class="table-column-name">Uniqname</strong>
+                    </th>
+                    <th scope="col" class="hide-small">
+                        <strong class="table-column-name">Student ID</strong>
+                    </th>
+                    <th scope="col" class="hide-small" data-sorter="false">
+                        <strong class="table-column-name">Status</strong>
+                    </th>
+                    <th scope="col" class="hide-small" data-sorter="false">
+                        <strong class="table-column-name">Cohorts</strong>
+                    </th>
+                </tr>
+                <tr>
+                    {% include 'seumich/ts_pager.html' with colspan="6" %}
+                </tr>
+            </tfoot>
+            <tbody>
+                {% for student in students %}
+                    <tr>
+                        <td scope="row" class="bold">
+                            <a href="{% url 'seumich:student' student.username %}">{{ student.first_name }}</a>
+                        </td>
+                        <td scope="row" class="bold">
+                            <a href="{% url 'seumich:student' student.username %}">{{ student.last_name }}</a>
+                        </td>
+                         <td scope="row" class="bold">
+                            <a href="{% url 'seumich:student' student.username %}">{{ student.username }}</a>
+                        </td>
+                        <td class="hide-small">{{ student.univ_id }}</td>
+                        <td data-text="{{student.status_calculated_value}}">
+                            {% for element in student.studentclasssitestatus_set.all %}
+                                {% with class_site=element.class_site %}
+                                <a href="{% url 'seumich:student_class' student.username class_site.code %}" class="class-site-status-link">
+                                    {% with status=element.status %}
+                                    {% if status.description == 'Green' %}
+                                        <span data-toggle="tooltip" title="{{ class_site.description }}: Encourage" data-placement="bottom">
+                                            <img src="{% static 'seumich/images/Status_Icons_Green.png' %}" alt="Green encourage status icon" width="25px" hspace="3"></img>
+                                        </span>
+                                    {% elif status.description == 'Yellow' %}
+                                        <span data-toggle="tooltip" title="{{ class_site.description }}: Explore" data-placement="bottom">
+                                            <img src="{% static 'seumich/images/Status_Icons_Yellow.png' %}" alt="Yellow explore status icon" width="25px" hspace="3"></img>
+                                        </span>
+                                    {% elif status.description == 'Red' %}
+                                        <span data-toggle="tooltip" title="{{ class_site.description }}: Engage" data-placement="bottom">
+                                            <img src="{% static 'seumich/images/Status_Icons_Red.png' %}" alt="Red engage status icon" width="25px" hspace="3"></img>
+                                        </span>
+                                    {% elif status.description == 'Not Applicable' %}
+                                        <span data-toggle="tooltip" title="{{ class_site.description }}: No data" data-placement="bottom">
+                                            <img src="{% static 'seumich/images/Status_Icons_Not Applicable.png' %}" alt="no status available for this course icon" width="25px" hspace="3"></img>
+                                        </span>
+                                    {% endif %}
+                                    {% endwith %}
+                                </a>
+                                {% endwith %}
+                            {% endfor %}
+                        </td>
+                        <td class="hide-small">
+                            {% for cohort in student.cohorts.all %}
+                                <div>{{ cohort }}</div>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endif %}
 {% endcache %}


### PR DESCRIPTION
This PR attempts to improve caching performance by moving an `if not students` condition from `advisor_detail.html` to `student_list_partial.html`. Previously, multiple queries were being fired when `advisor_detail` was processed, but caching can cover these queries if we move the check to `student_list_partial`.  To ensure `advisor_without_students.html` is only displayed on the My Students page, I combined the `not students` condition with a prior check for whether an `advisor` object is defined. This PR aims to resolve issue #175 and is related to #136.

Note: A similar issue exists with `student_list.html` (which is used with the search bar), where there is a `not_student` check. While it's likely possible to also move the check to `student_list_partial`, additional conditions would make the template more convoluted. Currently,  `student_list` produces a panel declaring "No students found that match the query terms" when the `not students` is true, which keeps it somewhat consistent with `advisor_detail`'s logic that produces a panel when no advisor is found. When possible, it seems better to keep the situation specific handling to the higher-level templates. I'm happy to discuss this further.