### PR TITLE
Caching intermediate-level templates using student_list_partial (#181)

### DIFF
--- a/seumich/templates/seumich/advisor_detail.html
+++ b/seumich/templates/seumich/advisor_detail.html
@@ -1,22 +1,25 @@
 {% extends 'seumich/advisor.html' %}
+{% load cache %}
 
 {% block content %}
-    <div class="container content">
-        {% if advisor %}
-            {% if not students %}
-                {% include 'seumich/advisor_without_students.html' %}
+    {% cache settings.CACHE_TTL advisor_detail request.get_full_path %}
+        <div class="container content">
+            {% if advisor %}
+                {% if not students %}
+                    {% include 'seumich/advisor_without_students.html' %}
+                {% else %}
+                    {% include 'seumich/student_list_partial.html' %}
+                {% endif %}
             {% else %}
-                {% include 'seumich/student_list_partial.html' %}
+                <div class="panel panel-warning not-found">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Not Found</h3>
+                    </div>
+                    <div class="panel-body">
+                        No advisor profile found.
+                    </div>
+                </div>
             {% endif %}
-        {% else %}
-            <div class="panel panel-warning not-found">
-                <div class="panel-heading">
-                    <h3 class="panel-title">Not Found</h3>
-                </div>
-                <div class="panel-body">
-                    No advisor profile found.
-                </div>
-            </div>
-        {% endif %}
-    </div>
+        </div>
+    {% endcache %}
 {% endblock %}

--- a/seumich/templates/seumich/class_site_detail.html
+++ b/seumich/templates/seumich/class_site_detail.html
@@ -1,18 +1,21 @@
 {% extends 'seumich/advisor.html' %}
+{% load cache %}
 
 {% block content %}
-    <div class="container content">
-        {% if class_site %}
-            {% include 'seumich/student_list_partial.html' %}
-        {% else %}
-            <div class="panel panel-warning not-found">
-                <div class="panel-heading">
-                    <h3 class="panel-title">Not Found</h3>
+    {% cache settings.CACHE_TTL class_site_detail request.get_full_path %}
+        <div class="container content">
+            {% if class_site %}
+                {% include 'seumich/student_list_partial.html' %}
+            {% else %}
+                <div class="panel panel-warning not-found">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Not Found</h3>
+                    </div>
+                    <div class="panel-body">
+                        No class site profile found.
+                    </div>
                 </div>
-                <div class="panel-body">
-                    No class site profile found.
-                </div>
-            </div>
-        {% endif %}
-    </div>
+            {% endif %}
+        </div>
+    {% endcache %}
 {% endblock %}

--- a/seumich/templates/seumich/cohort_detail.html
+++ b/seumich/templates/seumich/cohort_detail.html
@@ -1,18 +1,21 @@
 {% extends 'seumich/advisor.html' %}
+{% load cache %}
 
 {% block content %}
-    <div class="container content">
-        {% if cohort %}
-            {% include 'seumich/student_list_partial.html' %}
-        {% else %}
-            <div class="panel panel-warning not-found">
-                <div class="panel-heading">
-                    <h3 class="panel-title">Not Found</h3>
+    {% cache settings.CACHE_TTL cohort_detail request.get_full_path %}
+        <div class="container content">
+            {% if cohort %}
+                {% include 'seumich/student_list_partial.html' %}
+            {% else %}
+                <div class="panel panel-warning not-found">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Not Found</h3>
+                    </div>
+                    <div class="panel-body">
+                        No cohort profile found.
+                    </div>
                 </div>
-                <div class="panel-body">
-                    No cohort profile found.
-                </div>
-            </div>
-        {% endif %}
-    </div>
+            {% endif %}
+        </div>
+    {% endcache %}
 {% endblock %}

--- a/seumich/templates/seumich/student_list.html
+++ b/seumich/templates/seumich/student_list.html
@@ -1,20 +1,23 @@
 {% extends 'seumich/student.html' %}
+{% load cache %}
 
 {% block content %}
-    <div class="container content">
-        {% if not students %}
-            {% if user.is_authenticated %}
-                <div class="panel panel-warning">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">No Results</h3>
+    {% cache settings.CACHE_TTL student_list request.get_full_path %}
+        <div class="container content">
+            {% if not students %}
+                {% if user.is_authenticated %}
+                    <div class="panel panel-warning">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">No Results</h3>
+                        </div>
+                        <div class="panel-body">
+                            No students found that match the query terms.
+                        </div>
                     </div>
-                    <div class="panel-body">
-                        No students found that match the query terms.
-                    </div>
-                </div>
+                {% endif %}
+            {% else %}
+                {% include 'seumich/student_list_partial.html' %}
             {% endif %}
-        {% else %}
-            {% include 'seumich/student_list_partial.html' %}
-        {% endif %}
-    </div>
+        </div>
+    {% endcache %}
 {% endblock %}

--- a/seumich/templates/seumich/student_list_partial.html
+++ b/seumich/templates/seumich/student_list_partial.html
@@ -1,7 +1,6 @@
 {% load filters %}
 {% load static from staticfiles %}
-{% load cache %}
-{% cache settings.CACHE_TTL student_list_partial request.get_full_path %}
+
 <script src='{% static 'seumich/sort_table.js' %}'></script>
 
 <h1 class="sub-header">{{ studentListHeader }}</h1>
@@ -108,4 +107,3 @@
     </table>
 
 </div>
-{% endcache %}


### PR DESCRIPTION
This PR moves existing template caching from the lowest level, in `student_list_partial`, up to four templates that `include` that leaf node template: `advisor_detail` (an advisor's "My Student" list), `student_list` (results from a search bar query), `cohort_detail` (list of students in a cohort), and `class_site_detail` (list of students in a class). While this results in extra lines of code, the advantage is that `if` conditions in the higher level templates will be covered by caching (and thus not generate new SQL queries as they were when only caching `student_list_partial`). This also enables us to keep logic related to each specific use case at a higher level, rather than be combined at the lower level as we started to do in the now closed #179. The PR aims to resolve issues #175 and #181 and is related to issues #122 and #136.