### PR TITLE
Making SAML entityId configurable (#187)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,9 +21,6 @@ DJANGO_DEBUG=true
 # Debug level can conflict with Django Debug Toolbar
 DJANGO_LOGGING_LEVEL=INFO
 
-# department affiliation string from MCommunity settings
-DEPT_AFFILIATION
-
 # Uncomment these values and define the location and options of the cache 
 # if you want to enable Redis (or other) caching
 
@@ -100,3 +97,6 @@ DEPT_AFFILIATION
 # URL pattern for course
 # https://xxxx/courses/
 # CANVAS_COURSE_URL_PREFIX=
+
+# department affiliation string from MCommunity settings
+# DEPT_AFFILIATION

--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,9 @@ DJANGO_DEBUG=true
 # Debug level can conflict with Django Debug Toolbar
 DJANGO_LOGGING_LEVEL=INFO
 
+# department affiliation string from MCommunity settings
+DEPT_AFFILIATION
+
 # Uncomment these values and define the location and options of the cache 
 # if you want to enable Redis (or other) caching
 
@@ -97,6 +100,3 @@ DJANGO_LOGGING_LEVEL=INFO
 # URL pattern for course
 # https://xxxx/courses/
 # CANVAS_COURSE_URL_PREFIX=
-
-# department affiliation string from MCommunity settings
-# DEPT_AFFILIATION

--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -190,9 +190,10 @@ if config('STUDENT_EXPLORER_SAML', default='no', cast=bool):
     SAML2_REMOTE_PEM_FILE = config('STUDENT_EXPLORER_SAML_REMOTE_PEM_FILE',default='')
 
     SAML2_DEFAULT_IDP = config('STUDENT_EXPLORER_SAML_DEFAULT_IDP',default='')
-
     if SAML2_DEFAULT_IDP:
         SAML2_DEFAULT_IDP = '?idp=%s' % SAML2_DEFAULT_IDP
+
+    SAML2_ENTITYID = config('SAML2_ENTITYID', default=SAML2_URL_BASE + 'metadata/')
 
     INSTALLED_APPS += ('djangosaml2',)
     AUTHENTICATION_BACKENDS = (
@@ -206,7 +207,7 @@ if config('STUDENT_EXPLORER_SAML', default='no', cast=bool):
     import saml2
     SAML_CONFIG = {
       'xmlsec_binary': '/usr/bin/xmlsec1',
-      'entityid': '%smetadata/' % SAML2_URL_BASE,
+      'entityid': SAML2_ENTITYID,
 
       # directory with attribute mapping
       # 'attribute_map_dir': os.path.join(BASE_DIR, 'attribute-maps'),


### PR DESCRIPTION
This PR makes a minor modification to `settings.py` to allow for users to specify a `SAML2_ENTITYID` as an environment variable,. If unspecified, the default we fall back upon is still to construct the `entityId` based on the base URL + `metadata/`. This change will allow us to move in the future toward global `entityId`s that can be shared among other T&L applications. I also commented out and moved a variable that I previously didn't realize was part of the now-unused cron. This PR aims to resolve issue #187.

Note: these changes are currently deployed to `test-studentexplorer.tl.it.umich.edu` for testing purposes.