### PR TITLE
Newlines in assignment comments, fixes issue #103

### DIFF
--- a/seumich/models.py
+++ b/seumich/models.py
@@ -1,8 +1,7 @@
 from django.db import models
 from seumich.mixins import SeumichDataMixin
 from django.utils import timezone
-import re  # Added for newlines in assignment comments fix
-
+import re  # Added for newlines in assignment comments fix --harryrs && csubram
 import logging, statistics
 
 logger = logging.getLogger(__name__)
@@ -370,7 +369,8 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
         db_column='CLASS_ASSGN_PNTS_ERND_NBR')
     included_in_grade = models.CharField(max_length=1,
                                          db_column='INCL_IN_CLASS_GRD_IND')
-    # Line below modified
+    # Identifier name modified to be distinct from new function name
+    # --harryrs && csubram
     raw_grader_comment = models.CharField(max_length=4000, null=True,
                                       db_column='STDNT_ASSGN_GRDR_CMNT_TXT')
     weight = models.FloatField(max_length=126,
@@ -382,11 +382,19 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
         return '%s has assignment %s in %s' % (self.student, self.assignment,
                                                self.class_site)
     # Function to insert breaks in place of newline characters so HTML will
-    # actually render newlines
+    # actually render newlines --harryrs && csubram
     @property
     def grader_comment(self):
         if not self.raw_grader_comment == None:
-            return re.sub('/\n/g', '<br />', self.raw_grader_comment.rstrip())
+
+            # Functionally, <br> or <br /> would also work, but using <br><br />
+            # complies with XHTML standards, in case that is a necessity of this
+            # project --harryrs && csubram
+            return re.sub(
+                '/\n/g',
+                '<br><br />',
+                self.raw_grader_comment.rstrip()
+            )
 
     @property
     def due_date(self):

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from seumich.mixins import SeumichDataMixin
 from django.utils import timezone
+import re  # Added for newlines in assignment comments fix
 
 import logging, statistics
 
@@ -369,7 +370,8 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
         db_column='CLASS_ASSGN_PNTS_ERND_NBR')
     included_in_grade = models.CharField(max_length=1,
                                          db_column='INCL_IN_CLASS_GRD_IND')
-    grader_comment = models.CharField(max_length=4000, null=True,
+    # Line below modified
+    raw_grader_comment = models.CharField(max_length=4000, null=True,
                                       db_column='STDNT_ASSGN_GRDR_CMNT_TXT')
     weight = models.FloatField(max_length=126,
                                db_column='ASSGN_WT_NBR')
@@ -379,6 +381,12 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
     def __str__(self):
         return '%s has assignment %s in %s' % (self.student, self.assignment,
                                                self.class_site)
+    # Function to insert breaks in place of newline characters so HTML will
+    # actually render newlines
+    @property
+    def grader_comment(self):
+        if not self.raw_grader_comment == None:
+            return re.sub('/\n/g', '<br />', self.raw_grader_comment.rstrip())
 
     @property
     def due_date(self):

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -389,7 +389,7 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
         # Check if grader comment is empty string and exit if so
         # --harryrs && csubram
         if self.raw_grader_comment is None:
-            return
+            return self.raw_grader_comment
 
         # Functionally, <br> or <br /> would also work, but using <br><br />
         # complies with XHTML standards, in case that is a necessity of this

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -385,16 +385,20 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
     # actually render newlines --harryrs && csubram
     @property
     def grader_comment(self):
-        if not self.raw_grader_comment == None:
 
-            # Functionally, <br> or <br /> would also work, but using <br><br />
-            # complies with XHTML standards, in case that is a necessity of this
-            # project --harryrs && csubram
-            return re.sub(
-                '/\n/g',
-                '<br><br />',
-                self.raw_grader_comment.rstrip()
-            )
+        # Check if grader comment is empty string and exit if so
+        # --harryrs && csubram
+        if self.raw_grader_comment is None:
+            return
+
+        # Functionally, <br> or <br /> would also work, but using <br><br />
+        # complies with XHTML standards, in case that is a necessity of this
+        # project --harryrs && csubram
+        return re.sub(
+            '/\n/g',
+            '<br><br />',
+            self.raw_grader_comment.rstrip()
+        )
 
     @property
     def due_date(self):

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -1,7 +1,8 @@
 from django.db import models
 from seumich.mixins import SeumichDataMixin
 from django.utils import timezone
-import re  # Added for newlines in assignment comments fix --harryrs && csubram
+import re  # Added for newlines in assignment comments fix
+
 import logging, statistics
 
 logger = logging.getLogger(__name__)
@@ -370,7 +371,6 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
     included_in_grade = models.CharField(max_length=1,
                                          db_column='INCL_IN_CLASS_GRD_IND')
     # Identifier name modified to be distinct from new function name
-    # --harryrs && csubram
     raw_grader_comment = models.CharField(max_length=4000, null=True,
                                       db_column='STDNT_ASSGN_GRDR_CMNT_TXT')
     weight = models.FloatField(max_length=126,
@@ -382,18 +382,17 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
         return '%s has assignment %s in %s' % (self.student, self.assignment,
                                                self.class_site)
     # Function to insert breaks in place of newline characters so HTML will
-    # actually render newlines --harryrs && csubram
+    # actually render newlines
     @property
     def grader_comment(self):
 
         # Check if grader comment is empty string and exit if so
-        # --harryrs && csubram
         if self.raw_grader_comment is None:
             return self.raw_grader_comment
 
         # Functionally, <br> or <br /> would also work, but using <br><br />
         # complies with XHTML standards, in case that is a necessity of this
-        # project --harryrs && csubram
+        # project
         return re.sub(
             '/\n/g',
             '<br><br />',


### PR DESCRIPTION
We have detailed the changes we made in our commit messages, but to summarize, we modified how the grader comments are processed in the models.py file. We import the Python regular expression library and substitute all instances of the '\n' character with a break tag so that the new line will actually render in HTML. The change is also XHTML-compliant, in case that is the intention for all of the web pages in the project. We have also signed all of our comments in the code so that our changes are easily identifiable.