### PR TITLE
Fixes #199 Clarify online programs info in 'About'

### DIFF
--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -4,35 +4,33 @@
     <div class="container content">
         <h1 class="sub-header">About Student Explorer</h1>
         <p>Student Explorer is an early warning system that <b>helps academic advisors identify at-risk students</b>
-            based on current term Learning Management System data. Using visualizations of data about students' current
-            term grades and assignments, it presents actionable intelligence to academic advisors. By helping them
-            identify students at risk of academic jeopardy, the tool enables advisors to create timely interventions
-            directing students toward resources that may facilitate behavioral change and academic growth and success.
-            For more information about how Student Explorer works and how to use it, please refer to the
-            <a href="https://documentation.its.umich.edu/student-explorer-general" target="_blank">Student Explorer documentation</a>.
+            based on current term Learning Management System data. It presents actionable intelligence to academic
+            advisors using visualizations of data about students' current term grades, activity, and assignments.
+            By helping them identify students at risk of academic jeopardy, the tool enables advisors to create timely
+            interventions directing students toward resources that may facilitate behavioral change and academic growth
+            and success. For more information about how Student Explorer works and how to use it, see
+            <a href="https://documentation.its.umich.edu/student-explorer-general">Student Explorer
+                Resources & Support</a>.
         </p>
 
         <h2 class="list-header">Student Explorer Access</h2>
-        <p>Student Explorer is available to all professional staff/faculty advisors at the U-M Ann Arbor campus upon request for access and includes information about all students on the Ann Arbor campus who use Canvas, including graduate
-            students (note: some graduate programs do not use Canvas and those students will not be visible in Student Explorer). Learn more about <a href="https://documentation.its.umich.edu/student-explorer-access" target="_blank">Student Explorer access</a>.
-        </p>
-
-        <h2 class="list-header">About Cohorts</h2>
-        <p>You can set up one or more lists of students, called "cohorts," so you can view all your students on your
-            <a href="/">"My Students" page</a>. You do not need to have students assigned to you through a cohort to
-            use Student Explorer. <a href="https://documentation.its.umich.edu/student-explorer-cohorts">Learn more
-                about cohorts and how to create them.</a>
+        <p>Student Explorer is available to professional staff/faculty advisors at the U-M Ann Arbor campus upon
+            request for access. It includes information about all students on the Ann Arbor campus who use Canvas,
+            including graduate students (note: some programs do not use Canvas and those students will not be
+            visible in Student Explorer). <a href="https://documentation.its.umich.edu/student-explorer-access">Learn
+                how to gain access to Student Explorer and how access is governed.</a>.
         </p>
 
         <h2 class="list-header">Student Explorer History</h2>
-        <p>Student Explorer started in 2011 as a University of Michigan USE Lab research project led by Professor Stephanie Teasley and Dr. Steven
-            Lonn in partnership with M-STEM Academies. LSA Technology Services, Academic Innovation, and ITS Teaching &
-            Learning have contributed to the design, development, and management of the tool.
+        <p>Student Explorer started in 2011 as a University of Michigan USE Lab research project led by Professor
+            Stephanie Teasley and Dr. Steven Lonn in partnership with M-STEM Academies. LSA Technology Services,
+            the Center for Academic Innovation, and ITS Teaching & Learning have contributed to the design, development,
+            and management of the tool.
         </p>
 
         <h2 class="list-header">Contact the Student Explorer Team</h2>
         <p>ITS Teaching & Learning manages Student Explorer; the Service Manager is
-            <a href="https://mcommunity.umich.edu/#profile:jmaggie" target="_blank">Maggie Davidson</a>. Get in touch by
+            <a href="https://mcommunity.umich.edu/#profile:jmaggie">Maggie Davidson</a>. Get in touch by
             <a href="/feedback">submitting feedback</a>!
         </p>
 
@@ -40,7 +38,7 @@
 
         <h2 class="list-header">Technical Information</h2>
         <p>The <a href="https://github.com/tl-its-umich-edu/student_explorer">GitHub repository</a> for Student Explorer
-            is public. View <a href="https://github.com/tl-its-umich-edu/student_explorer/releases">release notes</a>
+            is public. <a href="https://github.com/tl-its-umich-edu/student_explorer/releases">View release notes</a>
             for Student Explorer.
         </p>
 

--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -9,13 +9,12 @@
             identify students at risk of academic jeopardy, the tool enables advisors to create timely interventions
             directing students toward resources that may facilitate behavioral change and academic growth and success.
             For more information about how Student Explorer works and how to use it, please refer to the
-            <a href="https://documentation.its.umich.edu/student-explorer-general">Student Explorer documentation</a>.
+            <a href="https://documentation.its.umich.edu/student-explorer-general" target="_blank">Student Explorer documentation</a>.
         </p>
 
         <h2 class="list-header">Student Explorer Access</h2>
-        <p>Student Explorer is available to all professional staff/faculty advisors at the U-M Ann Arbor campus upon
-            request for access and includes information about all students on the Ann Arbor campus, including graduate
-            students. Students, including peer advisors, are not able to gain access to Student Explorer.
+        <p>Student Explorer is available to all professional staff/faculty advisors at the U-M Ann Arbor campus upon request for access and includes information about all students on the Ann Arbor campus who use Canvas, including graduate
+            students (note: some graduate programs do not use Canvas and those students will not be visible in Student Explorer). Learn more about <a href="https://documentation.its.umich.edu/student-explorer-access" target="_blank">Student Explorer access</a>.
         </p>
 
         <h2 class="list-header">About Cohorts</h2>
@@ -26,7 +25,7 @@
         </p>
 
         <h2 class="list-header">Student Explorer History</h2>
-        <p>Student Explorer started in 2011 as a research project led by Professor Stephanie Teasley and Dr. Steven
+        <p>Student Explorer started in 2011 as a University of Michigan USE Lab research project led by Professor Stephanie Teasley and Dr. Steven
             Lonn in partnership with M-STEM Academies. LSA Technology Services, Academic Innovation, and ITS Teaching &
             Learning have contributed to the design, development, and management of the tool.
         </p>

--- a/student_explorer/templates/student_explorer/about.html
+++ b/student_explorer/templates/student_explorer/about.html
@@ -31,7 +31,7 @@
         <h2 class="list-header">Contact the Student Explorer Team</h2>
         <p>ITS Teaching & Learning manages Student Explorer; the Service Manager is
             <a href="https://mcommunity.umich.edu/#profile:jmaggie">Maggie Davidson</a>. Get in touch by
-            <a href="/feedback">submitting feedback</a>!
+            emailing <a href="mailto:student-explorer-help@umich.edu">student-explorer-help@umich.edu</a>!
         </p>
 
         <hr/>


### PR DESCRIPTION
Tweaked some language in the about page mostly focused on clarifying that not all A2 campus students are in Student Explorer if they don't use Canvas. Added link to more info on access.