### PR TITLE
Update Python, Django, other dependencies and fix related issues (#198)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 RUN apt-get update && apt-get --no-install-recommends install --yes \
     libaio1 libaio-dev xmlsec1 libffi-dev \

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -1,12 +1,10 @@
-
-
 from django.db import models
 from django.contrib.auth.models import User
 from django_extensions.db.models import TimeStampedModel
 
 
 class Feedback(TimeStampedModel):
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
     feedback_message = models.TextField()
 
     def __str__(self):

--- a/feedback/urls.py
+++ b/feedback/urls.py
@@ -1,6 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 from feedback import views
 
+app_name = 'feedback'
+
 urlpatterns = [
-    url(
-        r'^$', views.submitFeedback, name='feedback'), ]
+    path('', views.submitFeedback, name='feedback'),
+]

--- a/management/models.py
+++ b/management/models.py
@@ -1,5 +1,3 @@
-
-
 import logging
 from django.db import models
 
@@ -47,9 +45,9 @@ class Student(BaseModel):
 
 
 class StudentCohortMentor(BaseModel):
-    student = models.ForeignKey(Student)
-    cohort = models.ForeignKey(Cohort)
-    mentor = models.ForeignKey(Mentor)
+    student = models.ForeignKey(Student, on_delete=models.CASCADE)
+    cohort = models.ForeignKey(Cohort, on_delete=models.CASCADE)
+    mentor = models.ForeignKey(Mentor, on_delete=models.CASCADE)
 
     class Meta:
         unique_together = ('student', 'cohort', 'mentor')

--- a/management/urls.py
+++ b/management/urls.py
@@ -1,24 +1,21 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 app_name = 'management'
 urlpatterns = [
-    url(r'^$', views.IndexView.as_view(), name='index'),
-    url(r'^users/$', views.UserListView.as_view(), name='user-list'),
-    url(r'^cohorts/$', views.CohortListView.as_view(), name='cohort-list'),
-    url(r'^cohorts/add/$', views.AddCohortView.as_view(), name='add-cohort'),
-    url(r'^users/add/$', views.AddUserView.as_view(), name='add-user'),
-    url(r'^cohorts/download/$',
-        views.CohortListDownloadView.as_view(),
-        name='cohort-list-download'),
-    url(r'^cohorts/detail/download/$',
-        views.CohortDetailDownloadView.as_view(),
-        name='cohort-detail-download'),
-    url(r'^cohorts/(?P<code>[\s\w-]+)/members/download/$',
+    path('', views.IndexView.as_view(), name='index'),
+    path('users/', views.UserListView.as_view(), name='user-list'),
+    path('cohorts/', views.CohortListView.as_view(), name='cohort-list'),
+    path('cohorts/add/', views.AddCohortView.as_view(), name='add-cohort'),
+    path('users/add/', views.AddUserView.as_view(), name='add-user'),
+    path('cohorts/download/', views.CohortListDownloadView.as_view(), name='cohort-list-download'),
+    path('cohorts/detail/download/', views.CohortDetailDownloadView.as_view(), name='cohort-detail-download'),
+    # trying this without re_path, will need to test
+    path(
+        'cohorts/<code>/members/download/',
         views.CohortMembersDownloadView.as_view(),
-        name='cohort-members-download'),
-    url(r'^cohorts/(?P<code>[\s\w-]+)/members/$',
-        views.CohortMembersView.as_view(),
-        name='cohort-members'),
+        name='cohort-members-download'
+    ),
+    path('cohorts/<code>/members/', views.CohortMembersView.as_view(), name='cohort-members'),
 ]

--- a/management/urls.py
+++ b/management/urls.py
@@ -11,7 +11,6 @@ urlpatterns = [
     path('users/add/', views.AddUserView.as_view(), name='add-user'),
     path('cohorts/download/', views.CohortListDownloadView.as_view(), name='cohort-list-download'),
     path('cohorts/detail/download/', views.CohortDetailDownloadView.as_view(), name='cohort-detail-download'),
-    # trying this without re_path, will need to test
     path(
         'cohorts/<code>/members/download/',
         views.CohortMembersDownloadView.as_view(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,30 @@
-Django>=1.11,<1.11.99
-mysqlclient>=1.4.4,<1.4.99
-python-ldap==3.2.0
-requests==2.20,<2.20.99
-django-watchman==0.15.0,<0.15.99
-django-registration-redux==1.4
-django-extensions==1.7.4
-whitenoise==3.3.1,<3.3.99
+# We're waiting on Django 3 until it's further into the lifecycle.
+Django>=2.2.9,<2.2.99
+
+# Django-related libraries
 djangosaml2==0.17.2
-django-debug-toolbar>=2.0,<2.0.99
-xlrd==1.0.0
-xlwt==1.2.0
-
-libsass==0.16.0
 django-cron>=0.5.1,<0.5.99
-future-fstrings>=0.4.4,<0.4.99
-python-decouple>=3.1,<3.99
-
-ptvsd>=4.2.0,<4.2.99
+django-debug-toolbar>=2.1,<2.1.99
+django-extensions>=2.2.6,<2.2.99
+django-mysql>=3.3.0,<3.3.99
 django-ptvsd-debug==1.0.3
-python-dateutil==2.8.0
+django-redis>=4.11.0,<4.11.99
+django-registration-redux==2.7
+django-watchman>=1.0.0,<1.0.99
 
-django-redis>=4.10.0,<4.99
+# Should we investigate alternatives and remove this? (it hasn't been updated since 2016)
 django-settings-export>=1.2.1,<1.2.99
-django-mysql>=3.2.0,<3.2.99
-sqlparse>=0.3.0,<0.3.99
+
+libsass>=0.19.4,<0.19.99
+mysqlclient>=1.4.6,<1.4.99
+ptvsd>=4.3.2,<4.3.99
+python-decouple==3.3
+python-dateutil>=2.8.1,<2.8.99
+python-ldap==3.2.0
+requests>=2.22.0,<2.22.99
+whitenoise>=5.0.1,<5.0.9
+
+# Should we investigate alternatives and remove these?
+# They seem out of date; standard libraries might be able to replace them)
+xlrd==1.2.0
+xlwt==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 # We're waiting on Django 3 until it's further into the lifecycle.
 Django>=2.2.9,<2.2.99
-
-# Django-related libraries
 djangosaml2==0.17.2
 django-cron>=0.5.1,<0.5.99
 django-debug-toolbar>=2.1,<2.1.99
@@ -10,21 +8,15 @@ django-mysql>=3.3.0,<3.3.99
 django-ptvsd-debug==1.0.3
 django-redis>=4.11.0,<4.11.99
 django-registration-redux==2.7
-django-watchman>=1.0.0,<1.0.99
-
-# Should we investigate alternatives and remove this? (it hasn't been updated since 2016)
 django-settings-export>=1.2.1,<1.2.99
-
+django-watchman>=1.0.0,<1.0.99
 libsass>=0.19.4,<0.19.99
 mysqlclient>=1.4.6,<1.4.99
 ptvsd>=4.3.2,<4.3.99
-python-decouple==3.3
 python-dateutil>=2.8.1,<2.8.99
+python-decouple==3.3
 python-ldap==3.2.0
 requests>=2.22.0,<2.22.99
 whitenoise>=5.0.1,<5.0.9
-
-# Should we investigate alternatives and remove these?
-# They seem out of date; standard libraries might be able to replace them)
 xlrd==1.2.0
 xlwt==1.3.0

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -225,7 +225,7 @@ class Assignment(models.Model):
     id = models.IntegerField(primary_key=True, db_column='ASSGN_KEY')
     code = models.CharField(max_length=20, db_column='ASSGN_CD')
     description = models.CharField(max_length=50, db_column='ASSGN_DES')
-    source_system = models.ForeignKey(SourceSystem, db_column='SRC_SYS_KEY',
+    source_system = models.ForeignKey(SourceSystem, on_delete=models.CASCADE, db_column='SRC_SYS_KEY',
                                       null=True)
 
     def __str__(self):
@@ -240,7 +240,7 @@ class ClassSite(models.Model):
     code = models.CharField(max_length=20, db_column='CLASS_SITE_CD')
     description = models.CharField(max_length=50, db_column='CLASS_SITE_DES')
     terms = models.ManyToManyField('Term', through='ClassSiteTerm')
-    source_system = models.ForeignKey(SourceSystem, db_column='SRC_SYS_KEY',
+    source_system = models.ForeignKey(SourceSystem, on_delete=models.CASCADE, db_column='SRC_SYS_KEY',
                                       null=True)
 
     def __str__(self):
@@ -255,7 +255,7 @@ class Cohort(models.Model):
     code = models.CharField(max_length=20, db_column='CHRT_CD')
     description = models.CharField(max_length=50, db_column='CHRT_DES')
     group = models.CharField(max_length=100, db_column='CHRT_GRP_NM')
-    source_system = models.ForeignKey(SourceSystem, db_column='SRC_SYS_KEY',
+    source_system = models.ForeignKey(SourceSystem, on_delete=models.CASCADE, db_column='SRC_SYS_KEY',
                                       null=True)
 
     def __str__(self):
@@ -267,7 +267,7 @@ class Cohort(models.Model):
 
 class EventType(models.Model):
     id = models.IntegerField(primary_key=True, db_column='EVENT_TYP_KEY')
-    source_system = models.ForeignKey(SourceSystem, db_column='SRC_SYS_KEY',
+    source_system = models.ForeignKey(SourceSystem, on_delete=models.CASCADE, db_column='SRC_SYS_KEY',
                                       null=True)
     description = models.CharField(max_length=50, db_column='EVENT_TYP_NM')
 
@@ -283,8 +283,8 @@ class EventType(models.Model):
 
 class ClassSiteTerm(models.Model):
     id = models.IntegerField(primary_key=True, db_column='CLASS_SITE_TERM_KEY')
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
-    term = models.ForeignKey(Term, db_column='TERM_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
+    term = models.ForeignKey(Term, on_delete=models.CASCADE, db_column='TERM_KEY')
 
     def __str__(self):
         return '%s was held in %s' % (self.class_site, self.term)
@@ -294,10 +294,10 @@ class ClassSiteTerm(models.Model):
 
 
 class StudentAdvisorRole(models.Model):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    advisor = models.ForeignKey(Advisor, db_column='ADVSR_KEY')
-    role = models.ForeignKey(AdvisorRole, db_column='ADVSR_ROLE_KEY')
+    advisor = models.ForeignKey(Advisor, on_delete=models.CASCADE, db_column='ADVSR_KEY')
+    role = models.ForeignKey(AdvisorRole, on_delete=models.CASCADE, db_column='ADVSR_ROLE_KEY')
 
     def __str__(self):
         return '%s advises %s as %s' % (self.advisor, self.student, self.role)
@@ -308,10 +308,10 @@ class StudentAdvisorRole(models.Model):
 
 
 class StudentCohortMentor(models.Model):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    mentor = models.ForeignKey(Mentor, db_column='MNTR_KEY')
-    cohort = models.ForeignKey(Cohort, db_column='CHRT_KEY')
+    mentor = models.ForeignKey(Mentor, on_delete=models.CASCADE, db_column='MNTR_KEY')
+    cohort = models.ForeignKey(Cohort, on_delete=models.CASCADE, db_column='CHRT_KEY')
 
     def __str__(self):
         return '%s is in the %s cohort' % (self.student, self.cohort)
@@ -325,7 +325,7 @@ class StudentCohortMentor(models.Model):
 
 
 class ClassSiteScore(models.Model):
-    class_site = models.ForeignKey(ClassSite, primary_key=True,
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, primary_key=True,
                                    db_column='CLASS_SITE_KEY')
     current_score_average = models.FloatField(db_column="CLASS_CURR_SCR_AVG")
 
@@ -338,9 +338,9 @@ class ClassSiteScore(models.Model):
 
 
 class StudentClassSiteScore(models.Model):
-    student = models.ForeignKey(Student, primary_key=True,
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, primary_key=True,
                                 db_column='STDNT_KEY')
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
     current_score_average = models.FloatField(db_column="STDNT_CURR_SCR_AVG")
 
     def __str__(self):
@@ -353,10 +353,10 @@ class StudentClassSiteScore(models.Model):
 
 
 class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
-    assignment = models.ForeignKey(Assignment, db_column='ASSGN_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
+    assignment = models.ForeignKey(Assignment, on_delete=models.CASCADE, db_column='ASSGN_KEY')
     points_possible = models.FloatField(max_length=10,
                                         db_column='STDNT_ASSGN_PNTS_PSBL_NBR')
     points_earned = models.FloatField(max_length=10,
@@ -373,7 +373,7 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
                                       db_column='STDNT_ASSGN_GRDR_CMNT_TXT')
     weight = models.FloatField(max_length=126,
                                db_column='ASSGN_WT_NBR')
-    _due_date = models.ForeignKey(Date, db_column='ASSGN_DUE_SBMT_DT_KEY',
+    _due_date = models.ForeignKey(Date, on_delete=models.CASCADE, db_column='ASSGN_DUE_SBMT_DT_KEY',
                                   null=True)
 
     def __str__(self):
@@ -425,10 +425,10 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
 
 
 class StudentClassSiteStatus(models.Model):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
-    status = models.ForeignKey(Status, db_column='ACAD_PERF_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
+    status = models.ForeignKey(Status, on_delete=models.CASCADE, db_column='ACAD_PERF_KEY')
 
     def __str__(self):
         return '%s has status %s in %s' % (self.student, self.status,
@@ -441,9 +441,9 @@ class StudentClassSiteStatus(models.Model):
 
 
 class WeeklyClassSiteScore(models.Model):
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY',
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY',
                                    primary_key=True)
-    week_end_date = models.ForeignKey(Date, db_column='WEEK_END_DT_KEY')
+    week_end_date = models.ForeignKey(Date, on_delete=models.CASCADE, db_column='WEEK_END_DT_KEY')
     score = models.FloatField(db_column='CLASS_CURR_SCR_AVG')
 
     def __str__(self):
@@ -457,11 +457,11 @@ class WeeklyClassSiteScore(models.Model):
 
 
 class WeeklyStudentClassSiteEvent(models.Model):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
-    week_end_date = models.ForeignKey(Date, db_column='WEEK_END_DT_KEY')
-    event_type = models.ForeignKey(EventType, db_column='EVENT_TYP_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
+    week_end_date = models.ForeignKey(Date, on_delete=models.CASCADE, db_column='WEEK_END_DT_KEY')
+    event_type = models.ForeignKey(EventType, on_delete=models.CASCADE, db_column='EVENT_TYP_KEY')
 
     event_count = models.IntegerField(db_column='STDNT_WKLY_EVENT_CNT')
     cumulative_event_count = models.IntegerField(
@@ -482,10 +482,10 @@ class WeeklyStudentClassSiteEvent(models.Model):
 
 
 class WeeklyStudentClassSiteScore(models.Model):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
-    week_end_date = models.ForeignKey(Date, db_column='WEEK_END_DT_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
+    week_end_date = models.ForeignKey(Date, on_delete=models.CASCADE, db_column='WEEK_END_DT_KEY')
     score = models.FloatField(db_column='STDNT_CURR_SCR_AVG')
 
     def __str__(self):
@@ -499,11 +499,11 @@ class WeeklyStudentClassSiteScore(models.Model):
 
 
 class WeeklyStudentClassSiteStatus(models.Model):
-    student = models.ForeignKey(Student, db_column='STDNT_KEY',
+    student = models.ForeignKey(Student, on_delete=models.CASCADE, db_column='STDNT_KEY',
                                 primary_key=True)
-    class_site = models.ForeignKey(ClassSite, db_column='CLASS_SITE_KEY')
-    week_end_date = models.ForeignKey(Date, db_column='WEEK_END_DT_KEY')
-    status = models.ForeignKey(Status, db_column='ACAD_PERF_KEY')
+    class_site = models.ForeignKey(ClassSite, on_delete=models.CASCADE, db_column='CLASS_SITE_KEY')
+    week_end_date = models.ForeignKey(Date, on_delete=models.CASCADE, db_column='WEEK_END_DT_KEY')
+    status = models.ForeignKey(Status, on_delete=models.CASCADE, db_column='ACAD_PERF_KEY')
 
     def __str__(self):
         return '%s has status %s in %s on %s' % (

--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -1,9 +1,9 @@
 import os
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
+from django.urls import reverse
 from seumich.models import (UsernameField,
                             Advisor,
                             Date,
@@ -44,6 +44,7 @@ class SeumichTest(TestCase):
     status = Status.objects.get(id=1)
     term = Term.objects.get(id=1)
     fixtures = ['dev_users.json']
+    databases = ['default', 'seumich']
 
     def setUp(self):
         self.client = Client()

--- a/seumich/urls.py
+++ b/seumich/urls.py
@@ -13,35 +13,19 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import url
+from django.urls import path
 from seumich import views
 
+app_name = 'seumich'
+
 urlpatterns = [
-    url(r'^$',
-        views.IndexView.as_view(),
-        name='index'),
-    url(r'^advisors/$',
-        views.AdvisorsListView.as_view(),
-        name='advisors_list'),
-    url(r'^cohorts/$',
-        views.CohortsListView.as_view(),
-        name='cohorts_list'),
-    url(r'^advisors/(?P<advisor>[\s\w-]+)/$',
-        views.AdvisorView.as_view(),
-        name='advisor'),
-    url(r'^cohorts/(?P<code>[\s\w-]+)/$',
-        views.CohortView.as_view(),
-        name='cohort'),
-    url(r'^classes/(?P<class_site_id>\d+)/$',
-        views.ClassSiteView.as_view(),
-        name='class_site'),
-    url(r'^students/$',
-        views.StudentsListView.as_view(),
-        name='students_list'),
-    url(r'^students/(?P<student>\w+)/$',
-        views.StudentView.as_view(),
-        name='student'),
-    url(r'^students/(?P<student>\w+)/class_sites/(?P<classcode>[\w-]+)/$',
-        views.StudentClassSiteView.as_view(),
-        name='student_class'),
+    path('', views.IndexView.as_view(), name='index'),
+    path('advisors/', views.AdvisorsListView.as_view(), name='advisors_list'),
+    path('cohorts/', views.CohortsListView.as_view(), name='cohorts_list'),
+    path('advisors/<advisor>/', views.AdvisorView.as_view(), name='advisor'),
+    path('cohorts/<code>/', views.CohortView.as_view(), name='cohort'),
+    path('classes/<class_site_id>/', views.ClassSiteView.as_view(), name='class_site'),
+    path('students/', views.StudentsListView.as_view(), name='students_list'),
+    path('students/<student>/', views.StudentView.as_view(), name='student'),
+    path('students/<student>/class_sites/<classcode>/', views.StudentClassSiteView.as_view(), name='student_class'),
 ]

--- a/start.sh
+++ b/start.sh
@@ -46,7 +46,7 @@ if [ -z "${IS_CRON_POD}" ]; then
         echo Starting Runserver for development
         export PYTHONPATH="/usr/src/app:$PYTHONPATH"
         export DJANGO_SETTINGS_MODULE=student_explorer.settings
-        exec django-admin runserver --nothreading --ptvsd 0.0.0.0:${GUNICORN_PORT}
+        exec django-admin runserver --ptvsd 0.0.0.0:${GUNICORN_PORT}
     fi
 else
     if [ -z "${CRONTAB_SCHEDULE}" ]; then

--- a/student_explorer/backends.py
+++ b/student_explorer/backends.py
@@ -7,10 +7,10 @@ logger = logging.getLogger(__name__)
 
 
 class ActiveUserOnlySAML2Backend(Saml2Backend):
-    def authenticate(self, **kwargs):
+    def authenticate(self, request, **kwargs):
         user = None
         try:
-            user = super(ActiveUserOnlySAML2Backend, self).authenticate(**kwargs)
+            user = super(ActiveUserOnlySAML2Backend, self).authenticate(request, **kwargs)
         except Exception:
             # If there's any exception with this authenticate just return PermisisonDenied
             logger.exception("Exception thrown from authenticate")

--- a/student_explorer/middleware.py
+++ b/student_explorer/middleware.py
@@ -20,7 +20,7 @@ class LoggingMiddleware(MiddlewareMixin):
             )
         )
 
-        if hasattr(request, 'user') and request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user.is_authenticated:
             l.append(request.user.username)
         else:
             l.append('-')

--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -205,7 +205,6 @@ if config('STUDENT_EXPLORER_SAML', default='no', cast=bool):
 
     INSTALLED_APPS += ('djangosaml2',)
     AUTHENTICATION_BACKENDS = (
-        'django.contrib.auth.backends.ModelBackend',
         # Use a custom SAML backend to support disabled users
         'student_explorer.backends.ActiveUserOnlySAML2Backend',
     )
@@ -281,7 +280,11 @@ if config('STUDENT_EXPLORER_SAML', default='no', cast=bool):
         'givenName': ('first_name', ),
         'sn': ('last_name', ),
     }
-
+else:
+    # This is the default and used for localhost
+    AUTHENTICATION_BACKENDS = (
+        'django.contrib.auth.backends.ModelBackend',
+    )
 
 # Logging
 

--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -32,7 +32,7 @@ ADMINS = [('', config('DJANGO_ERROR_EMAIL', default='vagrant@localhost'))]
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django_ptvsd',
     'django.contrib.admin',
     'registration',
@@ -50,7 +50,7 @@ INSTALLED_APPS = (
     'feedback',
     'usage',
     'django_mysql',
-)
+]
 
 CRON_CLASSES = [
     "student_explorer.cron.StudentExplorerCronJob",
@@ -102,10 +102,10 @@ WATCHMAN_TOKEN = config('DJANGO_WATCHMAN_TOKEN', default=None)
 WATCHMAN_TOKEN_NAME = config('DJANGO_WATCHMAN_TOKEN_NAME', default='token')
 
 # Storage check is not included because filesystem is not writable
-WATCHMAN_CHECKS = (
+WATCHMAN_CHECKS = [
     'watchman.checks.caches',
     'watchman.checks.databases',
-)
+]
 
 DOWNLOAD_TOKEN = config('DJANGO_DOWNLOAD_TOKEN', default=None)
 
@@ -138,10 +138,10 @@ STATIC_ROOT = config('DJANGO_STATIC_ROOT',
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-STATICFILES_FINDERS = (
+STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-)
+]
 
 LOGIN_URL = config('DJANGO_LOGIN_URL', default='/accounts/login/')
 LOGIN_REDIRECT_URL = '/'
@@ -187,9 +187,9 @@ DATABASES['seumich'] = {
 DATABASE_ROUTERS += ['seumich.routers.SeumichRouter']
 
 # This is the default AUTHENTICATION_BACKENDS and used for localhost
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-)
+]
 
 # SAML Auth
 
@@ -207,11 +207,11 @@ if config('STUDENT_EXPLORER_SAML', default='no', cast=bool):
 
     SAML2_ENTITYID = config('SAML2_ENTITYID', default=SAML2_URL_BASE + 'metadata/')
 
-    INSTALLED_APPS += ('djangosaml2',)
-    AUTHENTICATION_BACKENDS = (
+    INSTALLED_APPS += ['djangosaml2']
+    AUTHENTICATION_BACKENDS = [
         # Use a custom SAML backend to support disabled users
         'student_explorer.backends.ActiveUserOnlySAML2Backend',
-    )
+    ]
     LOGIN_URL = '%slogin/%s' % (SAML2_URL_PATH, SAML2_DEFAULT_IDP)
     SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
@@ -370,7 +370,7 @@ if DEBUG:
     from debug_toolbar import settings as dt_settings
     DEBUG_TOOLBAR_PANELS = dt_settings.PANELS_DEFAULTS
     DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK" : show_debug_toolbar,}
-    INSTALLED_APPS += ('debug_toolbar',)
+    INSTALLED_APPS += ['debug_toolbar']
     MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 
 # Cache time to live

--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -66,7 +66,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'student_explorer.middleware.LoggingMiddleware',
@@ -183,8 +182,8 @@ DATABASES['seumich'] = {
     'HOST': config('DJANGO_SEUMICH_DB_HOST', default=''),
     'PORT': config('DJANGO_SEUMICH_DB_PORT', default=''),
     'MIGRATE': config('DJANGO_SEUMICH_DB_MIGRATE', default='no', cast=bool),
-
 }
+
 DATABASE_ROUTERS += ['seumich.routers.SeumichRouter']
 
 

--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -186,6 +186,10 @@ DATABASES['seumich'] = {
 
 DATABASE_ROUTERS += ['seumich.routers.SeumichRouter']
 
+# This is the default AUTHENTICATION_BACKENDS and used for localhost
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+)
 
 # SAML Auth
 
@@ -280,11 +284,6 @@ if config('STUDENT_EXPLORER_SAML', default='no', cast=bool):
         'givenName': ('first_name', ),
         'sn': ('last_name', ),
     }
-else:
-    # This is the default and used for localhost
-    AUTHENTICATION_BACKENDS = (
-        'django.contrib.auth.backends.ModelBackend',
-    )
 
 # Logging
 

--- a/student_explorer/urls.py
+++ b/student_explorer/urls.py
@@ -18,12 +18,13 @@ urlpatterns = [
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
         name="robots_file"
     ),
-    path('admin/', admin.site.urls),
     path('', include('seumich.urls', namespace='seumich')),
-    path('status/', include('watchman.urls')),
+    path('about', views.about, name='about'),
+    path('admin/', admin.site.urls),
     path('manage/', include('management.urls')),
     path('feedback/', include('feedback.urls', namespace='feedback')),
     path('usage/', include('usage.urls', namespace='usage')),
+    path('status/', include('watchman.urls')),
 ]
 
 # Override auth_logout from djangosaml2 and registration for consistent behavior
@@ -31,16 +32,14 @@ urlpatterns.append(path('accounts/logout/', views.logout, name='auth_logout'))
 
 if 'djangosaml2' in settings.INSTALLED_APPS:
     from djangosaml2.views import echo_attributes
-    urlpatterns += (
+    urlpatterns += [
         path('accounts/', include('djangosaml2.urls')),
         path('accounts/echo_attributes/', echo_attributes),
-    )
+    ]
 elif 'registration' in settings.INSTALLED_APPS:
-    urlpatterns += (
+    urlpatterns += [
         path('accounts/', include('registration.backends.default.urls')),
-    )
-
-urlpatterns.append(path('about', views.about, name='about'))
+    ]
 
 # Configure Django Debug Toolbar
 if settings.DEBUG:

--- a/student_explorer/urls.py
+++ b/student_explorer/urls.py
@@ -1,54 +1,50 @@
-"""student_explorer URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+student_explorer URL Configuration
+
+This file was originally created to work with Django 1.8. It has since been updated to use Django 2.2.
+Refer to the Django documentation at the following link for proper usage:
+https://docs.djangoproject.com/en/2.2/ref/urls/
+
+"""
+from django.urls import include, path
 from django.views.generic import TemplateView
 from django.contrib import admin
 from django.conf import settings
 from . import views
 
 urlpatterns = [
-    url(r'^robots.txt$', TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), name="robots_file"),
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^', include('seumich.urls', namespace='seumich')),
-    url(r'^status/', include('watchman.urls')),
-    url(r'^manage/', include('management.urls')),
-    url(r'^feedback/', include('feedback.urls', namespace='feedback')),
-    url(r'^usage/', include('usage.urls', namespace='usage')),
+    path(
+        'robots.txt',
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+        name="robots_file"
+    ),
+    path('admin/', admin.site.urls),
+    path('', include('seumich.urls', namespace='seumich')),
+    path('status/', include('watchman.urls')),
+    path('manage/', include('management.urls')),
+    path('feedback/', include('feedback.urls', namespace='feedback')),
+    path('usage/', include('usage.urls', namespace='usage')),
 ]
 
-# Override auth_logout from djangosaml2 and registration for consistant behavior
-urlpatterns.append(url(r'^accounts/logout/?', views.logout, name='auth_logout'))
+# Override auth_logout from djangosaml2 and registration for consistent behavior
+urlpatterns.append(path('accounts/logout/', views.logout, name='auth_logout'))
 
 if 'djangosaml2' in settings.INSTALLED_APPS:
     from djangosaml2.views import echo_attributes
     urlpatterns += (
-        url(r'^accounts/', include('djangosaml2.urls')),
-        url(r'^accounts/echo_attributes/', echo_attributes),
+        path('accounts/', include('djangosaml2.urls')),
+        path('accounts/echo_attributes/', echo_attributes),
     )
 elif 'registration' in settings.INSTALLED_APPS:
     urlpatterns += (
-        url(r'^accounts/', include('registration.backends.default.urls')),
+        path('accounts/', include('registration.backends.default.urls')),
     )
 
-urlpatterns.append(url(r'^about', views.about, name='about'))
-
+urlpatterns.append(path('about', views.about, name='about'))
 
 # Configure Django Debug Toolbar
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        path('__debug__/', include(debug_toolbar.urls)),
     ]

--- a/tracking/migrations/0001_initial.py
+++ b/tracking/migrations/0001_initial.py
@@ -21,8 +21,8 @@ class Migration(migrations.Migration):
                 ('timestamp', models.DateTimeField(auto_now_add=True)),
                 ('note', models.CharField(default='', max_length=255)),
                 ('related_object_id', models.PositiveIntegerField(null=True, blank=True)),
-                ('related_content_type', models.ForeignKey(blank=True, to='contenttypes.ContentType', null=True)),
-                ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('related_content_type', models.ForeignKey(on_delete=models.CASCADE, blank=True, to='contenttypes.ContentType', null=True)),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, blank=True, to=settings.AUTH_USER_MODEL, null=True)),
             ],
             options={
                 'ordering': ('-timestamp',),

--- a/tracking/models.py
+++ b/tracking/models.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from django.dispatch import Signal, receiver
@@ -8,12 +7,13 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 
 from django.conf import settings
 
+
 class Event(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, null=True, blank=True)
     name = models.CharField(max_length=100)
     timestamp = models.DateTimeField(auto_now_add=True)
     note = models.CharField(max_length=255, default='')
-    related_content_type = models.ForeignKey(ContentType, null=True, blank=True)
+    related_content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, null=True, blank=True)
     related_object_id = models.PositiveIntegerField(null=True, blank=True)
     related_object = GenericForeignKey('related_content_type', 'related_object_id')
 

--- a/tracking/urls.py
+++ b/tracking/urls.py
@@ -1,4 +1,6 @@
-from django.conf.urls import url, include
+from django.urls import path
 from tracking import views
 
-urlpatterns = [url(r'^record-event/$', views.record_event, name="record-event"),]
+urlpatterns = [
+    path('record-event/', views.record_event, name="record-event"),
+]

--- a/tracking/utils.py
+++ b/tracking/utils.py
@@ -16,12 +16,12 @@ def create_event(name, request=None, user=None, note=None, related_object=None):
     given, the user is pulled from the request, and in the absence of a note,
     the note is set to the request path."""
     if request is not None:        
-        if user is None and hasattr(request, 'user') and request.user.is_authenticated():
+        if user is None and hasattr(request, 'user') and request.user.is_authenticated:
             user = request.user
         if note is None:
             note = request.path
     e = Event(name=name)
-    if user is not None and user.is_authenticated():
+    if user is not None and user.is_authenticated:
         e.user = user
     if related_object is not None:
         e.related_object = related_object
@@ -37,7 +37,7 @@ def create_event(name, request=None, user=None, note=None, related_object=None):
 def user_log_page_view(f):
     @wraps(f)
     def wrapper(request, *args, **kwargs):
-        user = request.user if request.user.is_authenticated() else None
+        user = request.user if request.user.is_authenticated else None
         response = f(request, *args, **kwargs)
         if response.status_code != 200:
             if response.status_code == 302:

--- a/usage/urls.py
+++ b/usage/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 from usage import views
 
+app_name = 'usage'
+
 urlpatterns = [
-    url(r'^$', views.UsageView.as_view(), name='usage_index'),
-    url(r'^download/$', views.DownloadCsvView.as_view(),
-        name='usage_download'),
+    path('', views.UsageView.as_view(), name='usage_index'),
+    path('download/', views.DownloadCsvView.as_view(), name='usage_download'),
 ]


### PR DESCRIPTION
This (draft) PR updates the versions of Python and Django used to 3.7 and 2.2.9, respectively; uses more current releases of other dependencies when possible; and makes other related fixes, primarily to respond to Django's changing APIs and patterns. A list of tasks completed as part of this process is provide below. The PR aims to resolve issue #198.

- [x] Update `Dockerfile` to use Python 3.7 as a base image.
- [x] Update Django (to 2.2.9) and other dependencies (where possible) in `requirements.txt`.
- [x] Add `on_delete=models.CASCADE` to `*/models.py` and migration files as necessary.
- [x] Update `urlpatterns` to use `path()` (instead of `url()`)
- [x] Fix `urls.py` for non-`student_explorer` apps by adding `app_name` variables.
- [x] Remove `SessionAuthenticationMiddleware`.
- [x] Change use of `user.is_authenticated()` to `user.is_authenticated`.
- [x] Get `seumich/tests.py` to run successfully by specifying databases in `SeumichTest`.
- [x] Test all routes on local machine.
- [x] Test SAML when deployed to OpenShift.
- [x] Test add/lookup/deactivate user in management (MFLD)
- [x] Test Add/change permissions/deactivate/delete user in admin (MFLD)
- [x] Test feedback form. (MFLD)
- [x] Test all links from the advisor with no students route (MFLD)
- [x] Test all links in the header and footer (MFLD)
- [x] Test search - three different strings ["jmaggie","john","001"] (MFLD)
- [x] Test cohort creation/deactivation/deletion (MFLD)
  - [x] Create cohort in text box with spaces between student/advisor
  - [x] Create cohort in text box with tabs between student/advisor
  - [x] Create cohort in text box with commas between student/advisor
  - [x] Create cohort with Excel file .xls
  - [x] Create cohort with Excel file .xlsx
  - [x] Create cohort with invalid file like .pdf or .csv
  - [x] Cohorts with special characters are blocked
  - [x] Download .xls cohort file and format is correct
  - [x] Download .dat files and format is correct
  - [x] Deactivate cohort
  - [x] Activate cohort
  - [x] Delete active cohort
  - [x] Delete inactive cohort
- [x] Test tracking events (MFLD)
- [x] Test sort/filter on advisor list of students page (MFLD)
- [x] Test all routes when deployed to OpenShift. (MFLD)
  - [x] / --> /advisors/<advisor>
  - [x] /about
  - [x] /manage
  - [x] /manage/cohorts
  - [x] /manage/users
  - [x] /advisors
  - [x] /students/`<student>`
  - [x] /students/`<student>`/`<course>`
  - [x] /classes/`<classsitekey>`
  - [x] /cohorts/`<cohortcode>`
- [x] Evaluate outdated back-end dependencies (Note: I kicked work on this down the road since the dependencies in question still work fine; see issue #210).