### PR TITLE
Double curly braces in grader_comment before passing to format_html (#219)

### DIFF
--- a/seumich/fixtures/dev_data_drop_create_and_insert.sql
+++ b/seumich/fixtures/dev_data_drop_create_and_insert.sql
@@ -8017,7 +8017,7 @@ VALUES
 	(1,0,4,0,65,'Y',NULL,0,2133,14,2),
 	(1,10,6,220,183,'Y','This part looks good!\\nBut you need to work on this other part.\\n\\nI am confident you can succeed in this course!',0,2133,15,2),
 	(3,100,98,600,500,'Y','Good!',0,2113,17,1),
-	(3,10,8,180,150,'Y','',1,2121,10,2);
+	(3,10,8,180,150,'Y','{x,y}',1,2121,10,2);
 
 /*!40000 ALTER TABLE `"CNLYR002"."FC_STDNT_CLASS_ASSGN"` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -7,11 +7,6 @@ import logging, re, statistics
 
 logger = logging.getLogger(__name__)
 
-# Regular expression patterns
-NL_LITERAL_PATTERN = re.compile(r"\\n")
-L_BRACE_PATTERN = re.compile(r'{')
-R_BRACE_PATTERN = re.compile(r'}')
-
 
 class UsernameField(models.CharField):
     '''Convert case for data warehouse values. Only handles read situations,
@@ -390,10 +385,8 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
     @property
     def formatted_grader_comment(self):
         if not self.grader_comment:
-            return "None"
-        comment_with_repls = NL_LITERAL_PATTERN.sub("<br><br />", self.grader_comment.strip())
-        comment_with_repls = L_BRACE_PATTERN.sub(r'{{', comment_with_repls)
-        comment_with_repls = R_BRACE_PATTERN.sub(r'}}', comment_with_repls)
+            return 'None'
+        comment_with_repls = self.grader_comment.strip().replace('\\n', '<br><br />').replace('{', '{{').replace('}', '}}')
         return format_html(f'"{comment_with_repls}"')
 
     @property

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -7,6 +7,11 @@ import logging, re, statistics
 
 logger = logging.getLogger(__name__)
 
+# Regular expression patterns
+NL_LITERAL_PATTERN = re.compile(r"\\n")
+L_BRACE_PATTERN = re.compile(r'{')
+R_BRACE_PATTERN = re.compile(r'}')
+
 
 class UsernameField(models.CharField):
     '''Convert case for data warehouse values. Only handles read situations,
@@ -386,8 +391,9 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
     def formatted_grader_comment(self):
         if not self.grader_comment:
             return "None"
-        nl_literal_pattern = re.compile(r"\\n")
-        comment_with_repls = nl_literal_pattern.sub("<br><br />", self.grader_comment.strip())
+        comment_with_repls = NL_LITERAL_PATTERN.sub("<br><br />", self.grader_comment.strip())
+        comment_with_repls = L_BRACE_PATTERN.sub(r'{{', comment_with_repls)
+        comment_with_repls = R_BRACE_PATTERN.sub(r'}}', comment_with_repls)
         return format_html(f'"{comment_with_repls}"')
 
     @property
@@ -522,6 +528,7 @@ class WeeklyStudentClassSiteStatus(models.Model):
     class Meta:
         unique_together = ('student', 'class_site', 'week_end_date', 'status')
         db_table = '"CNLYR002"."FC_STDNT_CLS_WKLY_ACAD_PRF"'
+
 
 class LearningAnalyticsStats(models.Model):
     dw_data_nm = models.CharField(primary_key=True, max_length=50, db_column='DW_DATA_NM')

--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -340,7 +340,7 @@ class SeumichTest(TestCase):
     def test_studentclasssiteassignment_formatted_grader_comment_with_curly_braces(self):
         """
         Testing whether the formatted_grader_comment method
-        properly replaces '{' and '}' with '{{' and  '}}' in the 
+        properly replaces '{' and '}' with '{{' and  '}}' in the
         input string before passing it to format_html.
         """
         # Set up

--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -337,6 +337,27 @@ class SeumichTest(TestCase):
         matches = br_tag_pattern.findall(student_class_site_assignment.formatted_grader_comment)
         self.assertEqual(len(matches), 3)
 
+    def test_studentclasssiteassignment_formatted_grader_comment_with_curly_braces(self):
+        """
+        Testing whether the formatted_grader_comment method
+        properly replaces '{' and '}' with '{{' and  '}}' in the 
+        input string before passing it to format_html.
+        """
+        # Set up
+        self.client.login(username='burl', password='burl')
+        student_class_site_assignment = StudentClassSiteAssignment.objects.get(
+            student=Student.objects.get(id=3),
+            assignment=Assignment.objects.get(id=10),
+            class_site=ClassSite.objects.get(id=2)
+        )
+        # Test that '{something}' is present in the method's output.
+        curly_braces_exp_pattern = re.compile(r"{[^{}]+}")
+        match = curly_braces_exp_pattern.search(student_class_site_assignment.formatted_grader_comment)
+        self.assertTrue(match)
+        # Test that the page with the comment properly loads.
+        response = self.client.get('/students/shannon/class_sites/2/')
+        self.assertEqual(response.status_code, 200)
+
     def test_studentclasssiteassignment_relative_to_average(self):
         """
         Testing whether the student's relative to average


### PR DESCRIPTION
This PR makes some small changes to the `formatted_grader_comment` method on the `StudentClassSiteAssignment` model in `seumich` so that the frontend can successfully display curly braces. This is accomplished by using the `re` module to find and then double left and right braces before passing them to `format_html` at the end of method. Previously, code inside `format_html` was interpreting the braces as places to insert content (see [the Python docs](https://docs.python.org/3.3/library/string.html#format-string-syntax) and this [bug report](https://code.djangoproject.com/ticket/29179)). This PR aims to resolve issue #219.