### PR TITLE
Update formatted_grader_comment to catch newlines with or without \r (#224)

### DIFF
--- a/seumich/fixtures/dev_data_drop_create_and_insert.sql
+++ b/seumich/fixtures/dev_data_drop_create_and_insert.sql
@@ -8015,7 +8015,7 @@ VALUES
 	(1,10,4,220,165.5,'Y','',0,2128,12,2),
 	(1,15,12.3,330,279.7,'Y','',0,2133,13,2),
 	(1,0,4,0,65,'Y',NULL,0,2133,14,2),
-	(1,10,6,220,183,'Y','This part looks good!\\nBut you need to work on this other part.\\n\\nI am confident you can succeed in this course!',0,2133,15,2),
+	(1,10,6,220,183,'Y','This part looks good!\\nBut you need to work on this other part.\\n\\nI am confident you can succeed in this course!\\r\\n-Teacher',0,2133,15,2),
 	(3,100,98,600,500,'Y','Good!',0,2113,17,1),
 	(3,10,8,180,150,'Y','{x,y}',1,2121,10,2);
 

--- a/seumich/models.py
+++ b/seumich/models.py
@@ -7,6 +7,8 @@ import logging, re, statistics
 
 logger = logging.getLogger(__name__)
 
+NEWLINE_PATTERN = re.compile(r'(\\r)?\\n')
+
 
 class UsernameField(models.CharField):
     '''Convert case for data warehouse values. Only handles read situations,
@@ -386,7 +388,7 @@ class StudentClassSiteAssignment(models.Model, SeumichDataMixin):
     def formatted_grader_comment(self):
         if not self.grader_comment:
             return 'None'
-        comment_with_repls = self.grader_comment.strip().replace('\\n', '<br><br />').replace('{', '{{').replace('}', '}}')
+        comment_with_repls = NEWLINE_PATTERN.sub('<br><br />', self.grader_comment.strip().replace('{', '{{').replace('}', '}}'))
         return format_html(f'"{comment_with_repls}"')
 
     @property

--- a/seumich/tests.py
+++ b/seumich/tests.py
@@ -323,19 +323,20 @@ class SeumichTest(TestCase):
         self.assertEqual(
             round(student_class_site_assignment[0].class_percentage, 2), 84.76)
 
-    def test_studentclasssiteassignment_formatted_grader_comment(self):
+    def test_studentclasssiteassignment_formatted_grader_comment_with_newlines(self):
         """
         Testing whether the formatted_grader_comment method
-        properly replaces newline literals with HTML break tags
+        properly replaces newline literals (with or without \r) with
+        HTML break tags
         """
         student_class_site_assignment = StudentClassSiteAssignment.objects.get(
             student=Student.objects.get(id=1),
             assignment=Assignment.objects.get(id=15),
             class_site=ClassSite.objects.get(id=2)
         )
-        br_tag_pattern = re.compile("<br><br />")
-        matches = br_tag_pattern.findall(student_class_site_assignment.formatted_grader_comment)
-        self.assertEqual(len(matches), 3)
+        formatted_grader_comment = student_class_site_assignment.formatted_grader_comment
+        self.assertEqual(formatted_grader_comment.count('<br><br />'), 4)
+        self.assertTrue(r'\r' not in formatted_grader_comment)
 
     def test_studentclasssiteassignment_formatted_grader_comment_with_curly_braces(self):
         """


### PR DESCRIPTION
This PR changes `formatted_grader_comment` on the `StudentClassSiteAssignment` (again!) to catch and remove leading instances of `\r` (common in Windows environments) as part of the replacement of newline literals with break HTML tags. I accomplished this by using a regular expression that optionally allows for `\r` before `\n`. It made sense to use this regular expression approach because I found some other occurrences of the sequence `\r` (not intended as a carriage return, but part of some other string, I think) which we would not want to be affected via a simple replacement. I updated the fixture `.sql` file with an instance of `\\r\\n` and the test with an additional assertion. I also decided to rename the test case to be more specifically about newlines. The PR aims to resolve issue #224.