### PR TITLE
Bump Bootstrap version to 3.4.1 (#232)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "bootstrap": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
-      "integrity": "sha1-AjeLSmts56VeOt0e2uQa1590ZGo="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
     "components-font-awesome": {
       "version": "5.9.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "student_explorer",
   "version": "2.7.1",
   "dependencies": {
-    "bootstrap": "3.3.4",
+    "bootstrap": "3.4.1",
     "components-font-awesome": "5.9.0",
     "d3": "3.5.17",
     "jquery": "^3.4.1",


### PR DESCRIPTION
This PR bumps the version of `bootstrap` in `package.json` and `package-lock.json` to the latest patched version of `3.4.1`. A quick round of testing revealed no broken static routes or other issues. The PR aims to resolve issue #232.