### PR TITLE
Update package.json, bump jQuery (#244)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "student_explorer",
-  "version": "2.7.1",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       "integrity": "sha1-sS58yp0yhqxd7BLQpuxdzVeLXx0="
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
     "nvd3": {
       "version": "1.1.15-beta2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "student_explorer",
-  "version": "2.7.1",
+  "version": "2.7.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tl-its-umich-edu/student_explorer.git"
+  },
+  "license": "Apache-2.0",
   "dependencies": {
     "bootstrap": "3.4.1",
     "components-font-awesome": "5.9.0",
     "d3": "3.5.17",
-    "jquery": "^3.4.1",
+    "jquery": "3.5.0",
     "nvd3": "1.1.15-beta2",
     "tablesorter": "2.31.2"
   }


### PR DESCRIPTION
This PR updates `package.json` to include the newest minor release for `jQuery`, a `license` property, and a `repository` property (with the latter two eliminating some build/install warnings). The PR aims to resolve issue #244.

I elected to remove the `^` in front of the `jquery` version, since none of the other dependencies allow for minor releases; see docs for [explanation of version range syntax](https://docs.npmjs.com/about-semantic-versioning) https://docs.npmjs.com/about-semantic-versioning. GitHub has done a good job of alerting us to needed updates, so I favored consistency here.