### PR TITLE
Complete frontend maintenance (#260)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get update && apt-get --no-install-recommends install --yes \
     libaio1 libaio-dev xmlsec1 libffi-dev libsasl2-dev \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,67 @@
 {
   "name": "student_explorer",
-  "version": "2.7.3",
-  "lockfileVersion": 1,
+  "version": "2.8.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "student_explorer",
+      "version": "2.8.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bootstrap": "3.4.1",
+        "components-font-awesome": "5.9.0",
+        "d3": "3.5.17",
+        "jquery": "3.6.0",
+        "nvd3": "1.1.15-beta2",
+        "tablesorter": "2.31.3"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/components-font-awesome": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/components-font-awesome/-/components-font-awesome-5.9.0.tgz",
+      "integrity": "sha512-AjY5WwmKripvroQ1oYpCC4eK8efavSKUGN/ATgwcbyz/kRmojslH8l6Mrlxq071bdzBrZvCxi+RKgU5ao3bU+A=="
+    },
+    "node_modules/d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
+    "node_modules/d3-browserify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/d3-browserify/-/d3-browserify-3.4.12.tgz",
+      "integrity": "sha1-sS58yp0yhqxd7BLQpuxdzVeLXx0="
+    },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "node_modules/nvd3": {
+      "version": "1.1.15-beta2",
+      "resolved": "https://registry.npmjs.org/nvd3/-/nvd3-1.1.15-beta2.tgz",
+      "integrity": "sha1-EJPq+qjA54FyQ7aEgp1//1njhxk=",
+      "dependencies": {
+        "d3-browserify": "^3.4.12"
+      }
+    },
+    "node_modules/tablesorter": {
+      "version": "2.31.3",
+      "resolved": "https://registry.npmjs.org/tablesorter/-/tablesorter-2.31.3.tgz",
+      "integrity": "sha512-ueEzeKiMajDcCWnUoT1dOeNEaS1OmPh9+8J0O2Sjp3TTijMygH74EA9QNJiNkLJqULyNU0RhbKY26UMUq9iurA==",
+      "dependencies": {
+        "jquery": ">=1.2.6"
+      }
+    }
+  },
   "dependencies": {
     "bootstrap": {
       "version": "3.4.1",
@@ -25,9 +84,9 @@
       "integrity": "sha1-sS58yp0yhqxd7BLQpuxdzVeLXx0="
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "nvd3": {
       "version": "1.1.15-beta2",
@@ -38,9 +97,9 @@
       }
     },
     "tablesorter": {
-      "version": "2.31.2",
-      "resolved": "https://registry.npmjs.org/tablesorter/-/tablesorter-2.31.2.tgz",
-      "integrity": "sha512-e4ubgJpHNXHWm8tR+eGt2BPAqoOCY+uOQ6PVDCgtklCtJO6VHmORmjZdtm9aYqSqWsUih72wB0nS95JiXZ2l2g==",
+      "version": "2.31.3",
+      "resolved": "https://registry.npmjs.org/tablesorter/-/tablesorter-2.31.3.tgz",
+      "integrity": "sha512-ueEzeKiMajDcCWnUoT1dOeNEaS1OmPh9+8J0O2Sjp3TTijMygH74EA9QNJiNkLJqULyNU0RhbKY26UMUq9iurA==",
       "requires": {
         "jquery": ">=1.2.6"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "student_explorer",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tl-its-umich-edu/student_explorer.git"
@@ -10,8 +10,8 @@
     "bootstrap": "3.4.1",
     "components-font-awesome": "5.9.0",
     "d3": "3.5.17",
-    "jquery": "3.5.0",
+    "jquery": "3.6.0",
     "nvd3": "1.1.15-beta2",
-    "tablesorter": "2.31.2"
+    "tablesorter": "2.31.3"
   }
 }


### PR DESCRIPTION
This PR aims to resolve #260. Mainly the PR bumps `jquery` (in an effort to fix identified console errors/bugs) and moves `node` to 16 to keep us on supported versions during 2022. The lock file version has been updated to be in sync with the expected `npm` version associated with Node 16.

Note that some dependencies are quite old and others are not being touched here (`bootstrap`, `d3`, `nvd3`). However, there are no vulnerabilities reported by `npm audit`. The need for a major dependency upgrade is documented in #216.