### PR TITLE
Fixes #257 Removing unnecessary download from Oracle that was dumping output to console.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN if [ "$LOCALHOST_DEV" ] ; then \
     echo "LOCALHOST_DEV is not set, building production (Oracle) dependencies" && \
     # Converted to Debian format
     apt-get install --yes alien && \
-    curl -sO https://yum.oracle.com/repo/OracleLinux/OL7/oracle/instantclient/x86_64/getPackage/oracle-instantclient${ORACLE_CLIENT_VERSION}-basiclite-${ORACLE_CLIENT_VERSION_FULL}.x86_64.rpm https://yum.oracle.com/repo/OracleLinux/OL7/oracle/instantclient/x86_64/getPackage/oracle-instantclient${ORACLE_CLIENT_VERSION}-devel-${ORACLE_CLIENT_VERSION_FULL}.x86_64.rpm && \
+    curl -sO https://yum.oracle.com/repo/OracleLinux/OL7/oracle/instantclient/x86_64/getPackage/oracle-instantclient${ORACLE_CLIENT_VERSION}-basiclite-${ORACLE_CLIENT_VERSION_FULL}.x86_64.rpm && \
     alien oracle-instantclient*.rpm && \
     dpkg -i *.deb && rm *.deb *.rpm && \
     pip install cx_Oracle==7.0 \


### PR DESCRIPTION
I was reading on the [installation for the Oracle Python](https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html) that it only needs the basic lite, not the devel package. The previous syntax wasn't downloading that devel rpm, instead dumping it to the stdout. So I just removed it. 