### PR TITLE
Add customizable, conditional announcement banner (#268)

### DIFF
--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -41,6 +41,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
+    'django.contrib.flatpages',
     'watchman',
     'student_explorer',
     'seumich',
@@ -90,6 +92,8 @@ WSGI_APPLICATION = 'student_explorer.wsgi.application'
 USE_X_FORWARDED_HOST = config('DJANGO_USE_X_FORWARDED_HOST', default='no', cast=bool)
 
 FORCE_SCRIPT_NAME = config('DJANGO_FORCE_SCRIPT_NAME', default=None)
+
+SITE_ID = 1
 
 WATCHMAN_TOKEN = config('DJANGO_WATCHMAN_TOKEN', default=None)
 WATCHMAN_TOKEN_NAME = config('DJANGO_WATCHMAN_TOKEN_NAME', default='token')

--- a/student_explorer/settings.py
+++ b/student_explorer/settings.py
@@ -93,6 +93,8 @@ USE_X_FORWARDED_HOST = config('DJANGO_USE_X_FORWARDED_HOST', default='no', cast=
 
 FORCE_SCRIPT_NAME = config('DJANGO_FORCE_SCRIPT_NAME', default=None)
 
+# Added to support flatpages
+# https://docs.djangoproject.com/en/3.2/ref/contrib/flatpages/#installation
 SITE_ID = 1
 
 WATCHMAN_TOKEN = config('DJANGO_WATCHMAN_TOKEN', default=None)

--- a/student_explorer/templates/student_explorer/index.html
+++ b/student_explorer/templates/student_explorer/index.html
@@ -1,3 +1,5 @@
+{% load flatpages %}
+{% get_flatpages as flatpages %}
 <!doctype html>
 <html lang="en" class="no-js">
 
@@ -120,7 +122,11 @@
                 </div>
             </div>
         </nav>
-
+        {% for page in flatpages %}
+            {% if page.url == "/user-comm-banner/" %}
+                {{page.content|safe}}
+            {% endif %}
+        {% endfor %}
         <div class="container-index">
             {% if messages %}
                 <div class="container alert-message">

--- a/student_explorer/urls.py
+++ b/student_explorer/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('feedback/', include('feedback.urls', namespace='feedback')),
     path('usage/', include('usage.urls', namespace='usage')),
     path('status/', include('watchman.urls')),
+    path('pages/', include('django.contrib.flatpages.urls')),
 ]
 
 # Override auth_logout from djangosaml2 and registration for consistent behavior


### PR DESCRIPTION
This PR aims to resolve #268.

Screenshot
![Screenshot 2023-07-06 at 12 38 46 PM](https://github.com/tl-its-umich-edu/student_explorer/assets/35741256/30140c03-ed56-473e-825f-dec8bbf77e33)


Local test steps
- Start up app, log in using a superuser
- Go to `/admin/`
- Edit example site to have a `localhost:2082` domain.
- Add a flatpage with the URL `/user-comm-banner/` and the following content:
  ```
  <div class="alert alert-warning" role="alert">
    <p class="text-center container">
      Student Explorer will not be receiving new data (refreshed data) beyond December 2023. See <a>here</a> for more information about the tool's retirement and alternative data sources.
    </p>
  </div>
  ```
- Visit the homepage.

Resources
- https://docs.djangoproject.com/en/3.2/ref/contrib/flatpages/